### PR TITLE
Ft/generate doc c

### DIFF
--- a/Sources/ExercismSwift/Common/EntityIdentifier.swift
+++ b/Sources/ExercismSwift/Common/EntityIdentifier.swift
@@ -1,19 +1,22 @@
 import Foundation
 
-public struct EntityIdentifier<Marker, T: Codable>: CustomStringConvertible {
-    public let rawValue: T
+typealias UUIDv4 = String
 
-    public init(_ rawValue: T) {
+struct EntityIdentifier<Marker, T: Codable>: CustomStringConvertible {
+    let rawValue: T
+
+    init(_ rawValue: T) {
         self.rawValue = rawValue
     }
 
-    public var description: String {
+    var description: String {
         "ID<\(Marker.self)>:\(rawValue)"
     }
 }
 
 extension EntityIdentifier: Equatable where T: Equatable {
-    public static func == (lhs: EntityIdentifier<Marker, T>, rhs: EntityIdentifier<Marker, T>) -> Bool {
+    static func == (lhs: EntityIdentifier<Marker, T>,
+                           rhs: EntityIdentifier<Marker, T>) -> Bool {
         lhs.rawValue == rhs.rawValue
     }
 }
@@ -23,19 +26,19 @@ extension EntityIdentifier: Hashable where T: Hashable {}
 // MARK: - Codable
 
 extension EntityIdentifier: Codable {
-    public init(from decoder: Decoder) throws {
+    init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         rawValue = try container.decode(T.self)
     }
 
-    public func encode(to encoder: Encoder) throws {
+    func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(rawValue)
     }
 }
 
 extension EntityIdentifier where T == UUIDv4 {
-    public init() {
+    init() {
         self.init(UUIDv4())
     }
 }

--- a/Sources/ExercismSwift/Common/Logger.swift
+++ b/Sources/ExercismSwift/Common/Logger.swift
@@ -33,6 +33,7 @@ extension LogLevel: Comparable {
         return lhs.naturalIntegralValue < rhs.naturalIntegralValue
     }
 }
+
 protocol LoggerHandler: AnyObject {
     func log(level: LogLevel, message: String)
 }

--- a/Sources/ExercismSwift/Common/Logger.swift
+++ b/Sources/ExercismSwift/Common/Logger.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum LogLevel: String, CaseIterable {
+enum LogLevel: String, CaseIterable {
     case trace
     case debug
     case info
@@ -29,68 +29,65 @@ extension LogLevel {
 }
 
 extension LogLevel: Comparable {
-    public static func < (lhs: LogLevel, rhs: LogLevel) -> Bool {
+    static func < (lhs: LogLevel, rhs: LogLevel) -> Bool {
         return lhs.naturalIntegralValue < rhs.naturalIntegralValue
     }
 }
-
-public protocol LoggerHandler: AnyObject {
+protocol LoggerHandler: AnyObject {
     func log(level: LogLevel, message: String)
 }
 
-public final class Logger {
+final class Logger {
     var handler: LoggerHandler
     var level: LogLevel
-
+    
     init(handler: LoggerHandler, level: LogLevel) {
         self.handler = handler
         self.level = level
     }
-
-    public func trace(_ message: @autoclosure () -> String) {
+    
+    func trace(_ message: @autoclosure () -> String) {
         log(level: .trace, message())
     }
-
-    public func debug(_ message: @autoclosure () -> String) {
+    
+    func debug(_ message: @autoclosure () -> String) {
         log(level: .debug, message())
     }
-
-    public func info(_ message: @autoclosure () -> String) {
+    
+    func info(_ message: @autoclosure () -> String) {
         log(level: .info, message())
     }
-
-    public func notice(_ message: @autoclosure () -> String) {
+    
+    func notice(_ message: @autoclosure () -> String) {
         log(level: .notice, message())
     }
-
-    public func warning(_ message: @autoclosure () -> String) {
+    
+    func warning(_ message: @autoclosure () -> String) {
         log(level: .warning, message())
     }
-
-    public func error(_ message: @autoclosure () -> String) {
+    
+    func error(_ message: @autoclosure () -> String) {
         log(level: .error, message())
     }
-
-    func log(
-        level: LogLevel,
-        _ message: @autoclosure () -> String
-    ) {
+    
+    func log(level: LogLevel,
+             _ message: @autoclosure () -> String) {
         if self.level <= level {
             self.handler.log(level: level, message: message())
         }
     }
 }
 
-public class EmptyLogHandler: LoggerHandler {
-    public init() {}
+class EmptyLogHandler: LoggerHandler {
+    init() {}
     
-    public func log(level: LogLevel, message: String) {}
+    func log(level: LogLevel, message: String) {}
 }
 
-public class PrintLogHandler: LoggerHandler {
-    public init() {}
-
-    public func log(level: LogLevel, message: String) {
+class PrintLogHandler: LoggerHandler {
+    init() {}
+    
+    func log(level: LogLevel, message: String) {
         print("ExercismSwift \(level.rawValue.uppercased()): \(message)")
     }
 }

--- a/Sources/ExercismSwift/Common/SolutionManager.swift
+++ b/Sources/ExercismSwift/Common/SolutionManager.swift
@@ -4,62 +4,64 @@
 
 import Foundation
 
+/// A manager responsible for handling solution file downloads and organization.
 public class SolutionManager {
+    /// The `SolutionFile` downloaded from  `downloadSolution`
     let solution: SolutionFile
+
+    /// The network client used for downloading files.
     let client: NetworkClient
+
+    /// The file manager responsible for handling file operations.
     let fileManager: FileManager
 
-    public init(with solution: SolutionFile, client: NetworkClient) {
+    /// Initializes a new `SolutionManager` instance.
+    ///
+    /// - Parameters:
+    ///   - solution: The `SolutionFile` containing file details.
+    ///   - client: The `NetworkClient` used for downloading solution files.
+    ///   - fileManager: The `FileManager` instance for handling local file operations. Defaults to `FileManager.default`.
+    public init(with solution: SolutionFile,
+                client: NetworkClient,
+                fileManager: FileManager = FileManager.default) {
         self.solution = solution
         self.client = client
-        fileManager = FileManager.default
+        self.fileManager = fileManager
     }
 
-    func getOrCreateSolutionDir() throws -> URL {
-        do {
-            let docsFolder = try fileManager.url(
-                for: .documentDirectory,
-                in: .userDomainMask,
-                appropriateFor: nil,
-                create: true)
-
-            let solutionDir = docsFolder.appendingPathComponent("\(solution.exercise.trackId)/\(solution.exercise.id)/", isDirectory: true)
-
-            if !fileManager.fileExists(atPath: solutionDir.relativePath) {
-                try fileManager.createDirectory(atPath: solutionDir.path, withIntermediateDirectories: true)
-            }
-            return solutionDir
-        }
-    }
-
-    func downloadFile(at path: String, to destination: URL, completed: @escaping  (Result<URL, ExercismClientError>) -> Void) {
-        let url = URL(string: path, relativeTo: URL(string: solution.fileDownloadBaseUrl))!
-        client.download(from: url, to: destination, headers: [:]) { result in
-            completed(result)
-        }
-    }
-
-    public func download(_ completed: @escaping(URL?, ExercismClientError?) -> Void) {
+    /// Downloads all solution files to a local directory.
+    ///
+    /// - Parameter completed: A closure that returns the local directory URL or an error.
+    ///
+    /// - Note: This method creates the required directory structure before downloading files.
+    public func download(_ completed: @escaping (URL?, ExercismClientError?) -> Void) {
         let dispatchGroup = DispatchGroup()
         var error: ExercismClientError?
+
         do {
             let solutionDir = try getOrCreateSolutionDir()
+
             for file in solution.files {
                 dispatchGroup.enter()
                 var fileComponents = file.split(separator: "/")
                 let fileLen = fileComponents.count
                 var destPath = solutionDir
                 let fileName = fileComponents.last!.description
+
                 if fileLen > 1 {
                     fileComponents.removeLast()
-                    destPath = solutionDir.appendingPathComponent(fileComponents.joined(separator: "/"), isDirectory: true)
-                    try fileManager.createDirectory(atPath: destPath.path, withIntermediateDirectories: true)
+                    destPath = solutionDir
+                        .appendingPathComponent(fileComponents.joined(separator: "/"), isDirectory: true)
+                    try fileManager.createDirectory(atPath: destPath.path,
+                                                    withIntermediateDirectories: true)
                 }
+
                 downloadFile(at: file,
-                             to: destPath.appendingPathComponent(fileName)) { complete in
+                             to: destPath.appendingPathComponent(fileName)) { _ in
                     dispatchGroup.leave()
                 }
             }
+
             dispatchGroup.notify(queue: DispatchQueue.main) {
                 if let error = error {
                     completed(nil, error)
@@ -71,4 +73,43 @@ public class SolutionManager {
             completed(nil, .builderError(message: error.localizedDescription))
         }
     }
+
+    /// Retrieves or creates the local directory for storing solution files.
+    ///
+    /// - Returns: The URL of the solution directory.
+    /// - Throws: An error if the directory cannot be created.
+    private func getOrCreateSolutionDir() throws -> URL {
+        let docsFolder = try fileManager.url(for: .documentDirectory,
+                                             in: .userDomainMask,
+                                             appropriateFor: nil,
+                                             create: true)
+
+        let solutionDir = docsFolder
+            .appendingPathComponent("\(solution.exercise.trackId)/\(solution.exercise.id)/", isDirectory: true)
+
+        if !fileManager.fileExists(atPath: solutionDir.relativePath) {
+            try fileManager.createDirectory(atPath: solutionDir.path, withIntermediateDirectories: true)
+        }
+
+        return solutionDir
+    }
+
+    /// Downloads a single file from the solution's file download URL.
+    ///
+    /// - Parameters:
+    ///   - path: The file path to download.
+    ///   - destination: The local destination URL for the downloaded file.
+    ///   - completed: A closure that returns a result containing the file URL or an error.
+    private func downloadFile(
+        at path: String,
+        to destination: URL,
+        completed: @escaping (Result<URL, ExercismClientError>) -> Void) {
+            let url = URL(string: path,
+                          relativeTo: URL(string: solution.fileDownloadBaseUrl))!
+            client.download(from: url,
+                            to: destination,
+                            headers: [:]) { result in
+                completed(result)
+            }
+        }
 }

--- a/Sources/ExercismSwift/Common/SolutionManager.swift
+++ b/Sources/ExercismSwift/Common/SolutionManager.swift
@@ -5,49 +5,49 @@
 import Foundation
 
 /// A manager responsible for handling solution file downloads and organization.
-public class SolutionManager {
+class SolutionManager {
     /// The `SolutionFile` downloaded from  `downloadSolution`
     let solution: SolutionFile
-
+    
     /// The network client used for downloading files.
     let client: NetworkClient
-
+    
     /// The file manager responsible for handling file operations.
     let fileManager: FileManager
-
+    
     /// Initializes a new `SolutionManager` instance.
     ///
     /// - Parameters:
     ///   - solution: The `SolutionFile` containing file details.
     ///   - client: The `NetworkClient` used for downloading solution files.
     ///   - fileManager: The `FileManager` instance for handling local file operations. Defaults to `FileManager.default`.
-    public init(with solution: SolutionFile,
-                client: NetworkClient,
-                fileManager: FileManager = FileManager.default) {
+    init(with solution: SolutionFile,
+         client: NetworkClient,
+         fileManager: FileManager = FileManager.default) {
         self.solution = solution
         self.client = client
         self.fileManager = fileManager
     }
-
+    
     /// Downloads all solution files to a local directory.
     ///
     /// - Parameter completed: A closure that returns the local directory URL or an error.
     ///
     /// - Note: This method creates the required directory structure before downloading files.
-    public func download(_ completed: @escaping (URL?, ExercismClientError?) -> Void) {
+    func download(_ completed: @escaping (URL?, ExercismClientError?) -> Void) {
         let dispatchGroup = DispatchGroup()
         var error: ExercismClientError?
-
+        
         do {
             let solutionDir = try getOrCreateSolutionDir()
-
+            
             for file in solution.files {
                 dispatchGroup.enter()
                 var fileComponents = file.split(separator: "/")
                 let fileLen = fileComponents.count
                 var destPath = solutionDir
                 let fileName = fileComponents.last!.description
-
+                
                 if fileLen > 1 {
                     fileComponents.removeLast()
                     destPath = solutionDir
@@ -55,13 +55,13 @@ public class SolutionManager {
                     try fileManager.createDirectory(atPath: destPath.path,
                                                     withIntermediateDirectories: true)
                 }
-
+                
                 downloadFile(at: file,
                              to: destPath.appendingPathComponent(fileName)) { _ in
                     dispatchGroup.leave()
                 }
             }
-
+            
             dispatchGroup.notify(queue: DispatchQueue.main) {
                 if let error = error {
                     completed(nil, error)
@@ -73,7 +73,7 @@ public class SolutionManager {
             completed(nil, .builderError(message: error.localizedDescription))
         }
     }
-
+    
     /// Retrieves or creates the local directory for storing solution files.
     ///
     /// - Returns: The URL of the solution directory.
@@ -83,33 +83,32 @@ public class SolutionManager {
                                              in: .userDomainMask,
                                              appropriateFor: nil,
                                              create: true)
-
+        
         let solutionDir = docsFolder
             .appendingPathComponent("\(solution.exercise.trackId)/\(solution.exercise.id)/", isDirectory: true)
-
+        
         if !fileManager.fileExists(atPath: solutionDir.relativePath) {
             try fileManager.createDirectory(atPath: solutionDir.path, withIntermediateDirectories: true)
         }
-
+        
         return solutionDir
     }
-
+    
     /// Downloads a single file from the solution's file download URL.
     ///
     /// - Parameters:
     ///   - path: The file path to download.
     ///   - destination: The local destination URL for the downloaded file.
     ///   - completed: A closure that returns a result containing the file URL or an error.
-    private func downloadFile(
-        at path: String,
-        to destination: URL,
-        completed: @escaping (Result<URL, ExercismClientError>) -> Void) {
-            let url = URL(string: path,
-                          relativeTo: URL(string: solution.fileDownloadBaseUrl))!
-            client.download(from: url,
-                            to: destination,
-                            headers: [:]) { result in
-                completed(result)
-            }
+    private func downloadFile(at path: String,
+                              to destination: URL,
+                              completed: @escaping (Result<URL, ExercismClientError>) -> Void) {
+        let url = URL(string: path,
+                      relativeTo: URL(string: solution.fileDownloadBaseUrl))!
+        client.download(from: url,
+                        to: destination,
+                        headers: [:]) { result in
+            completed(result)
         }
+    }
 }

--- a/Sources/ExercismSwift/Common/Types.swift
+++ b/Sources/ExercismSwift/Common/Types.swift
@@ -1,3 +1,0 @@
-import Foundation
-
-public typealias UUIDv4 = String

--- a/Sources/ExercismSwift/Environment.swift
+++ b/Sources/ExercismSwift/Environment.swift
@@ -3,7 +3,7 @@ import Foundation
 typealias DebugEnvironment = ExercismSwiftEnvironment
 
 struct ExercismSwiftEnvironment {
-    static var log = Logger(handler: PrintLogHandler(), level: .info)
+    static var log = Logger(handler: PrintLogHandler(), level: .trace)
     static var logHandler: LoggerHandler {
         get { log.handler }
         set { log.handler = newValue }

--- a/Sources/ExercismSwift/Environment.swift
+++ b/Sources/ExercismSwift/Environment.swift
@@ -1,15 +1,15 @@
 import Foundation
 
-public typealias DebugEnvironment = ExercismSwiftEnvironment
+typealias DebugEnvironment = ExercismSwiftEnvironment
 
-public struct ExercismSwiftEnvironment {
+struct ExercismSwiftEnvironment {
     static var log = Logger(handler: PrintLogHandler(), level: .info)
-    public static var logHandler: LoggerHandler {
+    static var logHandler: LoggerHandler {
         get { log.handler }
         set { log.handler = newValue }
     }
-
-    public static var logLevel: LogLevel {
+    
+    static var logLevel: LogLevel {
         get { log.level }
         set { log.level = newValue }
     }

--- a/Sources/ExercismSwift/ExercismClient+Badges.swift
+++ b/Sources/ExercismSwift/ExercismClient+Badges.swift
@@ -10,14 +10,14 @@ import Foundation
 // MARK: - Badges
 
 extension ExercismClient {
-    public func badges(completed: @escaping (Result<ListResponse<Exercise>, ExercismClientError>) -> Void
-    ) {
-        networkClient.get(
-            urlBuilder.url(path: ExercismClientPath.badges, params: [:]),
-            headers: headers(),
-            completed: completed
-        )
+    /// Fetches the list of badges earned by the user.
+    ///
+    /// - Parameter completed: A completion handler that returns a `Result` containing either a `ListResponse<Exercise>` with the earned badges or an `ExercismClientError` if the request fails.
+    public func badges(completed: @escaping (Result<ListResponse<Exercise>,
+                                             ExercismClientError>) -> Void) {
+        networkClient.get(from: urlBuilder.url(for: ExercismClientPath.badges,
+                                               params: [:]),
+                          headers: headers(),
+                          completed: completed)
     }
 }
-
-

--- a/Sources/ExercismSwift/ExercismClient+Exercises.swift
+++ b/Sources/ExercismSwift/ExercismClient+Exercises.swift
@@ -3,15 +3,16 @@ import Foundation
 // MARK: - Tracks
 
 extension ExercismClient {
-    public func exercises(
-        for track: String,
-        completed: @escaping (Result<ListResponse<Exercise>, ExercismClientError>) -> Void
-    ) {
-        networkClient.get(
-            urlBuilder.url(path: .exercises,
-                           urlArgs: track),
-            headers: headers(),
-            completed: completed
-        )
+    /// Fetches the list of exercises available for a given track.
+    ///
+    /// - Parameters:
+    ///   - track: The identifier of the track for which exercises are to be fetched.
+    ///   - completed: A completion handler that returns a `Result` containing either a `ListResponse<Exercise>` with the exercises or an `ExercismClientError` if the request fails.
+    public func exercises(for track: String,
+                          completed: @escaping (Result<ListResponse<Exercise>, ExercismClientError>) -> Void) {
+        networkClient.get(from: urlBuilder.url(for: .exercises,
+                                               urlArgs: track),
+                          headers: headers(),
+                          completed: completed)
     }
 }

--- a/Sources/ExercismSwift/ExercismClient+Solutions.swift
+++ b/Sources/ExercismSwift/ExercismClient+Solutions.swift
@@ -68,17 +68,17 @@ extension ExercismClient {
         networkClient.get(from: urlBuilder.url(for: .solutionsFile,
                                                params: params,
                                                urlArgs: id),
-                          headers: headers()) { (result: Result<SolutionFile,
+                          headers: headers()) { (result: Result<SolutionResponse,
                                                  ExercismClientError>) in
             switch result {
-            case .success(let solution):
-                let solutionManager = SolutionManager(with: solution,
+            case .success(let solutionResponse):
+                let solutionManager = SolutionManager(with: solutionResponse.solution,
                                                       client: self.networkClient)
                 solutionManager.download { url, error in
                     if let url = url {
                         do {
                             let exerciseDocument = try ExerciseDocument(exerciseDirectory: url,
-                                                                        solution: solution)
+                                                                        solution: solutionResponse.solution)
                             completed(.success(exerciseDocument))
                         } catch let error {
                             completed(.failure(.builderError(message: error.localizedDescription)))

--- a/Sources/ExercismSwift/ExercismClient+Solutions.swift
+++ b/Sources/ExercismSwift/ExercismClient+Solutions.swift
@@ -77,7 +77,7 @@ extension ExercismClient {
                 solutionManager.download { url, error in
                     if let url = url {
                         do {
-                            let exerciseDocument = try ExerciseDocument(exerciseDirectory: url,
+                            let exerciseDocument = try ExerciseDocument(with: url,
                                                                         solution: solutionResponse.solution)
                             completed(.success(exerciseDocument))
                         } catch let error {

--- a/Sources/ExercismSwift/ExercismClient+Solutions.swift
+++ b/Sources/ExercismSwift/ExercismClient+Solutions.swift
@@ -30,6 +30,15 @@ extension ExercismClient {
         )
     }
 
+    public func initialSolution(for solutionId: String,
+                                completed: @escaping (Result<InitialFiles, ExercismClientError>) -> Void) {
+        networkClient.get(
+            urlBuilder.url(path: .initialFiles, urlArgs: solutionId),
+            headers: headers(),
+            completed: completed
+        )
+    }
+
     public func downloadSolution(
         with id: String = "latest",
         for track: String,

--- a/Sources/ExercismSwift/ExercismClient+Solutions.swift
+++ b/Sources/ExercismSwift/ExercismClient+Solutions.swift
@@ -3,12 +3,19 @@ import Foundation
 // MARK: - Solutions
 
 extension ExercismClient {
-    public func solutions(
-        for track: String? = nil,
-        withStatus status: SolutionStatus? = nil,
-        mentoringStatus: MentoringStatus? = nil,
-        completed: @escaping (Result<ListResponse<Solution>, ExercismClientError>) -> Void
-    ) {
+
+    /// Fetches solutions for a given track with optional filters.
+    ///
+    /// - Parameters:
+    ///   - track: The track name associated with the solutions (optional).
+    ///   - status: The status of the solutions to fetch (optional).
+    ///   - mentoringStatus: The mentoring status of the solutions (optional).
+    ///   - completed: A completion handler that returns a `Result` containing either a list of solutions (`ListResponse<Solution>`) or an `ExercismClientError` if the request fails.
+    public func solutions(for track: String? = nil,
+                          withStatus status: SolutionStatus? = nil,
+                          mentoringStatus: MentoringStatus? = nil,
+                          completed: @escaping (Result<ListResponse<Solution>,
+                                                ExercismClientError>) -> Void) {
         var params: [String: String] = [:]
         if let t = track {
             params["track_slug"] = t
@@ -22,44 +29,56 @@ extension ExercismClient {
             params["mentoring_status"] = mt.rawValue
         }
 
-        networkClient.get(
-            urlBuilder.url(path: .solutions,
-                           params: params),
-            headers: headers(),
-            completed: completed
-        )
+        networkClient.get(from: urlBuilder.url(for: .solutions,
+                                               params: params),
+                          headers: headers(),
+                          completed: completed)
     }
 
+    /// Fetches the initial solution files for a given solution so that user can revert to the original state of the given exercise.
+    ///
+    /// - Parameters:
+    ///   - solutionId: The unique identifier of the solution.
+    ///   - completed: A completion handler that returns a `Result` containing either the initial solution files (`InitialFiles`) or an `ExercismClientError` if the request fails.
     public func initialSolution(for solutionId: String,
-                                completed: @escaping (Result<InitialFiles, ExercismClientError>) -> Void) {
-        networkClient.get(
-            urlBuilder.url(path: .initialFiles, urlArgs: solutionId),
-            headers: headers(),
-            completed: completed
-        )
+                                completed: @escaping (Result<InitialFiles,
+                                                      ExercismClientError>) -> Void) {
+        networkClient.get(from: urlBuilder.url(for: .initialFiles,
+                                               urlArgs: solutionId),
+                          headers: headers(),
+                          completed: completed)
     }
 
-    public func downloadSolution(
-        with id: String = "latest",
-        for track: String,
-        exercise: String,
-        completed: @escaping (Result<ExerciseDocument, ExercismClientError>) -> Void
-    ) {
+    /// Downloads the solution file for a given exercise.
+    ///
+    /// - Parameters:
+    ///   - id: The solution identifier. Defaults to `"latest"`, which fetches the most recent solution.
+    ///   - track: The track ID to which the exercise belongs.
+    ///   - exercise: The exercise ID for which the solution is being downloaded.
+    ///   - completed: A completion handler that returns a `Result` containing either an `ExerciseDocument` if successful or an `ExercismClientError` if the request fails.
+    public func downloadSolution(with id: String = "latest",
+                                 for track: String,
+                                 exercise: String,
+                                 completed: @escaping (Result<ExerciseDocument,
+                                                       ExercismClientError>) -> Void) {
         var params: [String: String] = [:]
         params["track_id"] = track
         params["exercise_id"] = exercise
 
-        networkClient.get(
-            urlBuilder.url(path: .solutionsFile, params: params, urlArgs: id),
-            headers: headers()
-        ) { (result: Result<SolutionFile, ExercismClientError>) in
+        networkClient.get(from: urlBuilder.url(for: .solutionsFile,
+                                               params: params,
+                                               urlArgs: id),
+                          headers: headers()) { (result: Result<SolutionFile,
+                                                 ExercismClientError>) in
             switch result {
             case .success(let solution):
-                let solutionManager = SolutionManager(with: solution, client: self.networkClient)
+                let solutionManager = SolutionManager(with: solution,
+                                                      client: self.networkClient)
                 solutionManager.download { url, error in
                     if let url = url {
                         do {
-                            let exerciseDocument = try ExerciseDocument(exerciseDirectory: url, solution: solution)
+                            let exerciseDocument = try ExerciseDocument(exerciseDirectory: url,
+                                                                        solution: solution)
                             completed(.success(exerciseDocument))
                         } catch let error {
                             completed(.failure(.builderError(message: error.localizedDescription)))
@@ -74,15 +93,17 @@ extension ExercismClient {
             }
         }
     }
-    
-    public func getIterations(
-        for solutionId: String,
-        completed: @escaping (Result<IterationResponse, ExercismClientError>) -> Void
-    ) {
-        networkClient.get(
-            urlBuilder.url(path: .iteration, urlArgs: solutionId),
-            headers: headers(),
-            completed: completed
-        )
+
+    /// Fetches the iteration history for a given solution.
+    ///
+    /// - Parameters:
+    ///   - solutionId: The unique identifier of the solution.
+    ///   - completed: A completion handler that returns a `Result` containing either an `IterationResponse` if successful or an `ExercismClientError` if the request fails.
+    public func getIterations(for solutionId: String,
+                              completed: @escaping (Result<IterationResponse, ExercismClientError>) -> Void) {
+        networkClient.get(from: urlBuilder.url(for: .iteration,
+                                               urlArgs: solutionId),
+                          headers: headers(),
+                          completed: completed)
     }
 }

--- a/Sources/ExercismSwift/ExercismClient+Submissions.swift
+++ b/Sources/ExercismSwift/ExercismClient+Submissions.swift
@@ -21,7 +21,7 @@ extension ExercismClient {
                            headers: headers(),
                            completed: completed)
     }
-
+    
     /// Retrieves the `TestRunResponse`
     ///
     /// - Parameters:
@@ -34,7 +34,7 @@ extension ExercismClient {
                           headers: headers(),
                           completed: completed)
     }
-
+    
     /// Cancels an ongoing test run.
     ///
     /// - Parameters:
@@ -46,7 +46,7 @@ extension ExercismClient {
                           headers: headers(),
                           completed: completed)
     }
-
+    
     /// Submits a solution for review.
     ///
     /// This action is performed after successfully running and passing all tests.
@@ -61,7 +61,7 @@ extension ExercismClient {
                 completed(.failure(.builderError(message: "Invalid URL")))
                 return
             }
-
+            
             networkClient.post(
                 to: url,
                 body: "",
@@ -69,7 +69,7 @@ extension ExercismClient {
                 completed: completed
             )
         }
-
+    
     /// Marks a solution as complete, optionally publishing it and specifying an iteration.
     ///
     /// This action is performed after submitting the solution and successfully passing all tests.

--- a/Sources/ExercismSwift/ExercismClient+Submissions.swift
+++ b/Sources/ExercismSwift/ExercismClient+Submissions.swift
@@ -1,58 +1,93 @@
-import Foundation
-
 // Submission of test and solutions.
 //
 // Created by Kirk Agbenyegah on 04/02/2023.
 //
 
+import Foundation
+
 extension ExercismClient {
-    public func runTest(
-        for solution: String,
-        withFileContents contents: [SolutionFileData],
-        completed: @escaping (Result<TestSubmission, ExercismClientError>) -> Void
-    ) {
+    /// Runs tests for a given solution with the provided file contents.
+    ///
+    /// - Parameters:
+    ///   - solution: The identifier of the solution to be tested.
+    ///   - contents: A list of `SolutionFileData` representing the file contents used for testing.
+    ///   - completed: A completion handler returning a `Result` with either a `TestSubmission` on success or an `ExercismClientError` on failure.
+    public func runTest(for solution: String,
+                        with contents: [SolutionFileData],
+                        completed: @escaping (Result<TestSubmission, ExercismClientError>) -> Void) {
         let files = SolutionTestFiles(files: contents)
-        networkClient.post(
-            urlBuilder.url(path: .testSubmission, urlArgs: solution),
-            body: files,
-            headers: headers(),
-            completed: completed
-        )
+        networkClient.post(to: urlBuilder.url(for: .testSubmission, urlArgs: solution),
+                           body: files,
+                           headers: headers(),
+                           completed: completed)
     }
 
-    public func getTestRun(
-        withLink link: String,
-        completed: @escaping (Result<TestRunResponse, ExercismClientError>) -> Void
-    ) {
-        networkClient.get(URL(string: link)!, headers: headers(), completed: completed)
+    /// Retrieves the `TestRunResponse`
+    ///
+    /// - Parameters:
+    ///   - link: The URL link to fetch the test run status.
+    ///   - completed: A completion handler returning a `Result` with either a `TestRunResponse` on success or an `ExercismClientError` on failure.
+    public func getTestRun(withLink link: String,
+                           completed: @escaping (Result<TestRunResponse,
+                                                 ExercismClientError>) -> Void) {
+        networkClient.get(from: URL(string: link)!,
+                          headers: headers(),
+                          completed: completed)
     }
 
-    public func cancelTestRun(
-        withLink link: String,
-        completed: @escaping (Result<TestSubmission, ExercismClientError>) -> Void
-    ) {
-        networkClient.get(URL(string: link)!, headers: headers(), completed: completed)
+    /// Cancels an ongoing test run.
+    ///
+    /// - Parameters:
+    ///   - link: The URL link to cancel the test run.
+    ///   - completed: A completion handler returning a `Result` with either a `TestSubmission` on success or an `ExercismClientError` on failure.
+    public func cancelTestRun(withLink link: String,
+                              completed: @escaping (Result<TestSubmission, ExercismClientError>) -> Void) {
+        networkClient.get(from: URL(string: link)!,
+                          headers: headers(),
+                          completed: completed)
     }
 
+    /// Submits a solution for review.
+    ///
+    /// This action is performed after successfully running and passing all tests.
+    ///
+    /// - Parameters:
+    ///   - link: The URL used to submit the solution.
+    ///   - completed: A completion handler returning a `Result` with either a `SubmitSolutionResponse` on success or an `ExercismClientError` on failure.
     public func submitSolution(
         withLink link: String,
-        completed: @escaping (Result<SubmitSolutionResponse, ExercismClientError>) -> Void
-    ) {
-        networkClient.post(URL(string: link)!, body: "", headers: headers(), completed: completed)
-    }
+        completed: @escaping (Result<SubmitSolutionResponse, ExercismClientError>) -> Void) {
+            guard let url = URL(string: link) else {
+                completed(.failure(.builderError(message: "Invalid URL")))
+                return
+            }
 
-    public func completeSolution(
-        for solution: String,
-        publish: Bool = false,
-        iteration: Int? = nil,
-        completed: @escaping (Result<CompletedSolution, ExercismClientError>) -> Void
-    ) {
+            networkClient.post(
+                to: url,
+                body: "",
+                headers: headers(),
+                completed: completed
+            )
+        }
+
+    /// Marks a solution as complete, optionally publishing it and specifying an iteration.
+    ///
+    /// This action is performed after submitting the solution and successfully passing all tests.
+    ///
+    /// - Parameters:
+    ///   - solution: The identifier of the solution to be completed.
+    ///   - publish: A boolean indicating whether to publish the solution (default is `false`).
+    ///   - iteration: An optional iteration number to complete, if applicable.
+    ///   - completed: A completion handler returning a `Result` with either a `CompletedSolution` on success or an `ExercismClientError` on failure.
+    public func completeSolution(for solution: String,
+                                 publish: Bool = false,
+                                 iteration: Int? = nil,
+                                 completed: @escaping (Result<CompletedSolution, ExercismClientError>) -> Void) {
         let payload = CompleteSolutionPayload(publish: publish, iteration: iteration)
-        networkClient.patch(urlBuilder.url(path: .completeSolution, urlArgs: solution), body: payload, headers: headers(), completed: completed)
-    }
-
-    struct CompleteSolutionPayload: Codable {
-        let publish: Bool
-        let iteration: Int?
+        networkClient.patch(to: urlBuilder.url(for: .completeSolution,
+                                               urlArgs: solution),
+                            body: payload,
+                            headers: headers(),
+                            completed: completed)
     }
 }

--- a/Sources/ExercismSwift/ExercismClient+Submissions.swift
+++ b/Sources/ExercismSwift/ExercismClient+Submissions.swift
@@ -54,16 +54,14 @@ extension ExercismClient {
     /// - Parameters:
     ///   - link: The URL used to submit the solution.
     ///   - completed: A completion handler returning a `Result` with either a `SubmitSolutionResponse` on success or an `ExercismClientError` on failure.
-    public func submitSolution(
-        withLink link: String,
+    public func submitSolution(withLink link: String,
         completed: @escaping (Result<SubmitSolutionResponse, ExercismClientError>) -> Void) {
             guard let url = URL(string: link) else {
                 completed(.failure(.builderError(message: "Invalid URL")))
                 return
             }
             
-            networkClient.post(
-                to: url,
+            networkClient.post(to: url,
                 body: "",
                 headers: headers(),
                 completed: completed

--- a/Sources/ExercismSwift/ExercismClient+Tracks.swift
+++ b/Sources/ExercismSwift/ExercismClient+Tracks.swift
@@ -8,8 +8,8 @@ extension ExercismClient {
     /// - Parameter completed: A completion handler returning a `Result` with either a `ListResponse<Track>` on success or an `ExercismClientError` on failure.
     public func tracks(completed: @escaping (Result<ListResponse<Track>,
                                              ExercismClientError>) -> Void) {
-            networkClient.get(from: urlBuilder.url(for: .tracks),
-                              headers: headers(),
-                              completed: completed)
-        }
+        networkClient.get(from: urlBuilder.url(for: .tracks),
+                          headers: headers(),
+                          completed: completed)
+    }
 }

--- a/Sources/ExercismSwift/ExercismClient+Tracks.swift
+++ b/Sources/ExercismSwift/ExercismClient+Tracks.swift
@@ -6,8 +6,8 @@ extension ExercismClient {
     /// Fetches a list of available tracks.
     ///
     /// - Parameter completed: A completion handler returning a `Result` with either a `ListResponse<Track>` on success or an `ExercismClientError` on failure.
-    public func tracks(
-        completed: @escaping (Result<ListResponse<Track>, ExercismClientError>) -> Void) {
+    public func tracks(completed: @escaping (Result<ListResponse<Track>,
+                                             ExercismClientError>) -> Void) {
             networkClient.get(from: urlBuilder.url(for: .tracks),
                               headers: headers(),
                               completed: completed)

--- a/Sources/ExercismSwift/ExercismClient+Tracks.swift
+++ b/Sources/ExercismSwift/ExercismClient+Tracks.swift
@@ -3,13 +3,13 @@ import Foundation
 // MARK: - Tracks
 
 extension ExercismClient {
+    /// Fetches a list of available tracks.
+    ///
+    /// - Parameter completed: A completion handler returning a `Result` with either a `ListResponse<Track>` on success or an `ExercismClientError` on failure.
     public func tracks(
-        completed: @escaping (Result<ListResponse<Track>, ExercismClientError>) -> Void
-    ) {
-        networkClient.get(
-            urlBuilder.url(path: .tracks),
-            headers: headers(),
-            completed: completed
-        )
-    }
+        completed: @escaping (Result<ListResponse<Track>, ExercismClientError>) -> Void) {
+            networkClient.get(from: urlBuilder.url(for: .tracks),
+                              headers: headers(),
+                              completed: completed)
+        }
 }

--- a/Sources/ExercismSwift/ExercismClient+ValidateToken.swift
+++ b/Sources/ExercismSwift/ExercismClient+ValidateToken.swift
@@ -6,10 +6,10 @@ extension ExercismClient {
     /// Validates the user's authentication token.
     ///
     /// - Parameter completed: A completion handler returning a `Result` with either a `ValidateTokenResponse` on success or an `ExercismClientError` on failure.
-    public func validateToken(
-        completed: @escaping (Result<ValidateTokenResponse, ExercismClientError>) -> Void) {
-            networkClient.get(from: urlBuilder.url(for: .validateToken),
-                              headers: headers(),
-                              completed: completed)
-        }
+    public func validateToken(completed: @escaping (Result<ValidateTokenResponse,
+                                                    ExercismClientError>) -> Void) {
+        networkClient.get(from: urlBuilder.url(for: .validateToken),
+                          headers: headers(),
+                          completed: completed)
+    }
 }

--- a/Sources/ExercismSwift/ExercismClient+ValidateToken.swift
+++ b/Sources/ExercismSwift/ExercismClient+ValidateToken.swift
@@ -3,13 +3,13 @@ import Foundation
 // MARK: - Tracks
 
 extension ExercismClient {
+    /// Validates the user's authentication token.
+    ///
+    /// - Parameter completed: A completion handler returning a `Result` with either a `ValidateTokenResponse` on success or an `ExercismClientError` on failure.
     public func validateToken(
-        completed: @escaping (Result<ValidateTokenResponse, ExercismClientError>) -> Void
-    ) {
-        networkClient.get(
-            urlBuilder.url(path: .validateToken),
-            headers: headers(),
-            completed: completed
-        )
-    }
+        completed: @escaping (Result<ValidateTokenResponse, ExercismClientError>) -> Void) {
+            networkClient.get(from: urlBuilder.url(for: .validateToken),
+                              headers: headers(),
+                              completed: completed)
+        }
 }

--- a/Sources/ExercismSwift/ExercismClient.swift
+++ b/Sources/ExercismSwift/ExercismClient.swift
@@ -1,26 +1,35 @@
 import Foundation
 
+/// A client for interacting with the Exercism API.
+/// Handles network requests and authentication using an API token.
 public final class ExercismClient: ExercismClientType {
+    /// The API token used for authentication.
     private var apiToken: String? = nil
+
+    /// The network client responsible for making API requests.
     let networkClient: NetworkClient
 
-    private let userAgent = "Exercism macOS"
+    /// The URL builder used to construct API request URLs.
     let urlBuilder = URLBuilder()
 
-    public init(
-            apiToken: String,
-            networkClient: NetworkClient? = nil
-    ) {
+    /// Initializes the client with an API token and an optional network client.
+    /// - Parameters:
+    ///   - apiToken: The API token for authentication.
+    ///   - networkClient: An optional network client. If `nil`, a `DefaultNetworkClient` is used.
+    public init(apiToken: String,
+                networkClient: NetworkClient? = nil) {
         self.apiToken = apiToken
         self.networkClient = networkClient ?? DefaultNetworkClient(apiToken)
     }
 
-    public init(
-            networkClient: NetworkClient? = nil
-    ) {
+    /// Initializes the client with an optional network client.
+    /// - Parameter networkClient: An optional network client. If `nil`, a `DefaultNetworkClient` is used.
+    public init(networkClient: NetworkClient? = nil) {
         self.networkClient = networkClient ?? DefaultNetworkClient(apiToken)
     }
 
+    /// Returns the default HTTP headers used for network requests.
+    /// - Returns: A dictionary of HTTP headers.
     func headers() -> Network.HTTPHeaders {
         [:]
     }

--- a/Sources/ExercismSwift/ExercismClient.swift
+++ b/Sources/ExercismSwift/ExercismClient.swift
@@ -5,13 +5,13 @@ import Foundation
 public final class ExercismClient: ExercismClientType {
     /// The API token used for authentication.
     private var apiToken: String? = nil
-
+    
     /// The network client responsible for making API requests.
     let networkClient: NetworkClient
-
+    
     /// The URL builder used to construct API request URLs.
     let urlBuilder = URLBuilder()
-
+    
     /// Initializes the client with an API token and an optional network client.
     /// - Parameters:
     ///   - apiToken: The API token for authentication.
@@ -21,13 +21,13 @@ public final class ExercismClient: ExercismClientType {
         self.apiToken = apiToken
         self.networkClient = networkClient ?? DefaultNetworkClient(apiToken)
     }
-
+    
     /// Initializes the client with an optional network client.
     /// - Parameter networkClient: An optional network client. If `nil`, a `DefaultNetworkClient` is used.
     public init(networkClient: NetworkClient? = nil) {
         self.networkClient = networkClient ?? DefaultNetworkClient(apiToken)
     }
-
+    
     /// Returns the default HTTP headers used for network requests.
     /// - Returns: A dictionary of HTTP headers.
     func headers() -> Network.HTTPHeaders {

--- a/Sources/ExercismSwift/ExercismClientError.swift
+++ b/Sources/ExercismSwift/ExercismClientError.swift
@@ -7,7 +7,7 @@ public enum ExercismClientError: Error {
     case decodingError(Error)
     case unsupportedResponseError
     case builderError(message: String)
-
+    
     public var description: String {
         switch self {
         case .genericError(let underlyingError):

--- a/Sources/ExercismSwift/ExercismClientPath.swift
+++ b/Sources/ExercismSwift/ExercismClientPath.swift
@@ -5,7 +5,7 @@
 //  Created by Angie Mugo on 26/09/2022.
 //
 
-public enum ExercismClientPath:  String {
+public enum ExercismClientPath: String {
     case exercises = "/v2/tracks/%@/exercises"
     case tracks = "/v2/tracks"
     case validateToken = "/v2/validate_token"
@@ -15,4 +15,5 @@ public enum ExercismClientPath:  String {
     case testSubmission = "/v2/solutions/%@/submissions"
     case iteration = "/v2/solutions/%@?sideload[]=iterations"
     case completeSolution = "/v2/solutions/%@/complete"
+    case initialFiles = "/v2/solutions/%@/initial_files"
 }

--- a/Sources/ExercismSwift/ExercismClientType.swift
+++ b/Sources/ExercismSwift/ExercismClientType.swift
@@ -1,33 +1,29 @@
 import Foundation
 
 public protocol ExercismClientType: AnyObject {
-    func tracks(
-        completed: @escaping (Result<ListResponse<Track>, ExercismClientError>) -> Void
-    )
-    
+    func tracks(completed: @escaping (Result<ListResponse<Track>,
+                                      ExercismClientError>) -> Void)
+
     func exercises(for track: String,
-                   completed: @escaping (Result<ListResponse<Exercise>, ExercismClientError>) -> Void
-    )
-    
-    func validateToken(
-        completed: @escaping (Result<ValidateTokenResponse, ExercismClientError>) -> Void
-    )
-    
-    func solutions(
-        for track: String?,
-        withStatus status: SolutionStatus?,
-        mentoringStatus: MentoringStatus?,
-        completed: @escaping (Result<ListResponse<Solution>, ExercismClientError>) -> Void
-    )
-    
-    func downloadSolution(
-        with id: String,
-        for track: String,
-        exercise: String,
-        completed: @escaping (Result<ExerciseDocument, ExercismClientError>) -> Void
-    )
-    
+                   completed: @escaping (Result<ListResponse<Exercise>,
+                                         ExercismClientError>) -> Void)
+
+    func validateToken(completed: @escaping (Result<ValidateTokenResponse,
+                                             ExercismClientError>) -> Void)
+
+    func solutions(for track: String?,
+                   withStatus status: SolutionStatus?,
+                   mentoringStatus: MentoringStatus?,
+                   completed: @escaping (Result<ListResponse<Solution>,
+                                         ExercismClientError>) -> Void)
+
+    func downloadSolution(with id: String,
+                          for track: String,
+                          exercise: String,
+                          completed: @escaping (Result<ExerciseDocument,
+                                                ExercismClientError>) -> Void)
+
     func initialSolution(for track: String,
-                         completed: @escaping (Result<InitialFiles, ExercismClientError>) -> Void
-    )
+                         completed: @escaping (Result<InitialFiles,
+                                               ExercismClientError>) -> Void)
 }

--- a/Sources/ExercismSwift/ExercismClientType.swift
+++ b/Sources/ExercismSwift/ExercismClientType.swift
@@ -3,26 +3,26 @@ import Foundation
 public protocol ExercismClientType: AnyObject {
     func tracks(completed: @escaping (Result<ListResponse<Track>,
                                       ExercismClientError>) -> Void)
-
+    
     func exercises(for track: String,
                    completed: @escaping (Result<ListResponse<Exercise>,
                                          ExercismClientError>) -> Void)
-
+    
     func validateToken(completed: @escaping (Result<ValidateTokenResponse,
                                              ExercismClientError>) -> Void)
-
+    
     func solutions(for track: String?,
                    withStatus status: SolutionStatus?,
                    mentoringStatus: MentoringStatus?,
                    completed: @escaping (Result<ListResponse<Solution>,
                                          ExercismClientError>) -> Void)
-
+    
     func downloadSolution(with id: String,
                           for track: String,
                           exercise: String,
                           completed: @escaping (Result<ExerciseDocument,
                                                 ExercismClientError>) -> Void)
-
+    
     func initialSolution(for track: String,
                          completed: @escaping (Result<InitialFiles,
                                                ExercismClientError>) -> Void)

--- a/Sources/ExercismSwift/ExercismClientType.swift
+++ b/Sources/ExercismSwift/ExercismClientType.swift
@@ -4,27 +4,30 @@ public protocol ExercismClientType: AnyObject {
     func tracks(
         completed: @escaping (Result<ListResponse<Track>, ExercismClientError>) -> Void
     )
-
+    
     func exercises(for track: String,
                    completed: @escaping (Result<ListResponse<Exercise>, ExercismClientError>) -> Void
     )
-
+    
     func validateToken(
         completed: @escaping (Result<ValidateTokenResponse, ExercismClientError>) -> Void
     )
-
+    
     func solutions(
         for track: String?,
         withStatus status: SolutionStatus?,
         mentoringStatus: MentoringStatus?,
         completed: @escaping (Result<ListResponse<Solution>, ExercismClientError>) -> Void
     )
-
+    
     func downloadSolution(
         with id: String,
         for track: String,
         exercise: String,
         completed: @escaping (Result<ExerciseDocument, ExercismClientError>) -> Void
     )
-
+    
+    func initialSolution(for track: String,
+                         completed: @escaping (Result<InitialFiles, ExercismClientError>) -> Void
+    )
 }

--- a/Sources/ExercismSwift/ExercismSwift.swift
+++ b/Sources/ExercismSwift/ExercismSwift.swift
@@ -1,6 +1,0 @@
-public struct ExercismSwift {
-    public private(set) var text = "Hello, World!"
-
-    public init() {
-    }
-}

--- a/Sources/ExercismSwift/Models/Badge.swift
+++ b/Sources/ExercismSwift/Models/Badge.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct Badge {
+public struct Badge: Decodable {
     public let uuid: String
     public let isRevealed: Bool
     public let unlockedAt: Date
@@ -18,33 +18,4 @@ public struct Badge {
     public let numAwardees: Int
     public let percentageAwardees: Int
     public let links: [BadgeLink]
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        uuid = try container.decode(String.self, forKey: .uuid)
-        isRevealed = try container.decode(Bool.self, forKey: .isRevealed)
-        unlockedAt = try container.decode(Date.self, forKey: .unlockedAt)
-        name = try container.decode(String.self, forKey: .name)
-        description = try container.decode(String.self, forKey: .description)
-        rarity = try container.decode(String.self, forKey: .rarity)
-        iconName = try container.decode(String.self, forKey: .iconName)
-        numAwardees = try container.decode(Int.self, forKey: .numAwardees)
-        percentageAwardees = try container.decode(Int.self, forKey: .percentageAwardees)
-        links = try container.decode([BadgeLink].self, forKey: .links)
-    }
-}
-
-extension Badge: Decodable {
-    enum CodingKeys: String, CodingKey {
-        case uuid
-        case isRevealed = "is_revealed"
-        case unlockedAt = "unlocked_at"
-        case name
-        case description = "blurb"
-        case rarity = "is_external"
-        case iconName = "icon_name"
-        case numAwardees = "num_awardees"
-        case percentageAwardees = "percentage_awardees"
-        case links
-    }
 }

--- a/Sources/ExercismSwift/Models/Badge.swift
+++ b/Sources/ExercismSwift/Models/Badge.swift
@@ -1,6 +1,6 @@
 //
 //  Badge.swift
-//  
+//
 //
 //  Created by Angie Mugo on 29/09/2022.
 //
@@ -18,7 +18,6 @@ public struct Badge {
     public let numAwardees: Int
     public let percentageAwardees: Int
     public let links: [BadgeLink]
-
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)

--- a/Sources/ExercismSwift/Models/BaseInfo.swift
+++ b/Sources/ExercismSwift/Models/BaseInfo.swift
@@ -4,24 +4,8 @@
 
 import Foundation
 
-public struct BaseInfo: Sendable {
+public struct BaseInfo: Sendable, Codable, Hashable {
     public let slug: String
     public let title: String
     public let iconUrl: String
-
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        slug = try container.decode(String.self, forKey: .slug)
-        title = try container.decode(String.self, forKey: .title)
-        iconUrl = try container.decode(String.self, forKey: .iconUrl)
-    }
-}
-
-extension BaseInfo: Codable, Hashable {
-    enum CodingKeys: String, CodingKey {
-        case slug
-        case title
-        case iconUrl = "icon_url"
-    }
 }

--- a/Sources/ExercismSwift/Models/CompleteSolutionModel.swift
+++ b/Sources/ExercismSwift/Models/CompleteSolutionModel.swift
@@ -1,0 +1,12 @@
+//
+//  CompleteSolutionModel.swift
+//  ExercismSwift
+//
+//  Created by Angie Mugo on 27/03/2025.
+//
+import Foundation
+
+struct CompleteSolutionPayload: Codable {
+    let publish: Bool
+    let iteration: Int?
+}

--- a/Sources/ExercismSwift/Models/CompletedSolution.swift
+++ b/Sources/ExercismSwift/Models/CompletedSolution.swift
@@ -10,23 +10,6 @@ public struct CompletedSolution: Decodable, Sendable {
     public let unlockedExercises: [Exercise]
     public let unlockedConcepts: [Concept]
     public let conceptProgressions: [ConceptProgressions]
-
-    enum CodingKeys: String, CodingKey {
-        case track
-        case exercise
-        case unlockedExercises = "unlocked_exercises"
-        case unlockedConcepts = "unlocked_concepts"
-        case conceptProgressions = "concept_progressions"
-    }
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        track = try container.decode(Track.self, forKey: .track)
-        exercise = try container.decode(Exercise.self, forKey: .exercise)
-        unlockedExercises = try container.decode([Exercise].self, forKey: .unlockedExercises)
-        unlockedConcepts = try container.decode([Concept].self, forKey: .unlockedConcepts)
-        conceptProgressions = try container.decode([ConceptProgressions].self, forKey: .conceptProgressions)
-    }
 }
 
 public struct Concept: Decodable, Sendable {

--- a/Sources/ExercismSwift/Models/ErrorDetail.swift
+++ b/Sources/ExercismSwift/Models/ErrorDetail.swift
@@ -4,11 +4,7 @@
 
 import Foundation
 
-public struct ErrorDetail {
+public struct ErrorDetail: Decodable {
     public let type: String
     public let message: String
 }
-
-extension ErrorDetail: Decodable {}
-
-

--- a/Sources/ExercismSwift/Models/ErrorDetail.swift
+++ b/Sources/ExercismSwift/Models/ErrorDetail.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-public struct ErrorDetail: Decodable {
-    public let type: String
-    public let message: String
+ struct ErrorDetail: Decodable {
+     let type: String
+     let message: String
 }

--- a/Sources/ExercismSwift/Models/ErrorResponse.swift
+++ b/Sources/ExercismSwift/Models/ErrorResponse.swift
@@ -1,5 +1,5 @@
 import Foundation
 
-public struct ErrorResponse: Decodable {
-    public let error: ErrorDetail
+ struct ErrorResponse: Decodable {
+     let error: ErrorDetail
 }

--- a/Sources/ExercismSwift/Models/ErrorResponse.swift
+++ b/Sources/ExercismSwift/Models/ErrorResponse.swift
@@ -1,9 +1,5 @@
 import Foundation
 
-public struct ErrorResponse {
+public struct ErrorResponse: Decodable {
     public let error: ErrorDetail
 }
-
-extension ErrorResponse: Decodable {}
-
-

--- a/Sources/ExercismSwift/Models/Exercise.swift
+++ b/Sources/ExercismSwift/Models/Exercise.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-public struct Exercise: Hashable, Sendable {
+public struct Exercise: Hashable, Sendable, Decodable {
     public let slug: String
     public let type: String
     public let iconUrl: String
@@ -14,31 +14,4 @@ public struct Exercise: Hashable, Sendable {
     public let isUnlocked: Bool
     public let isRecommended: Bool
     public let links: ResultLink
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        slug = try container.decode(String.self, forKey: .slug)
-        type = try container.decode(String.self, forKey: .type)
-        iconUrl = try container.decode(String.self, forKey: .iconUrl)
-        difficulty = try container.decode(String.self, forKey: .difficulty)
-        blurb = try container.decode(String.self, forKey: .blurb)
-        isExternal = try container.decode(Bool.self, forKey: .isExternal)
-        isUnlocked = try container.decode(Bool.self, forKey: .isUnlocked)
-        isRecommended = try container.decode(Bool.self, forKey: .isRecommended)
-        links = try container.decode(ResultLink.self, forKey: .links)
-    }
-}
-
-extension Exercise: Decodable {
-    enum CodingKeys: String, CodingKey {
-        case slug
-        case type
-        case iconUrl = "icon_url"
-        case difficulty
-        case blurb = "blurb"
-        case isExternal = "is_external"
-        case isUnlocked = "is_unlocked"
-        case isRecommended = "is_recommended"
-        case links
-    }
 }

--- a/Sources/ExercismSwift/Models/ExerciseDocument.swift
+++ b/Sources/ExercismSwift/Models/ExerciseDocument.swift
@@ -4,33 +4,68 @@
 
 import Foundation
 
+
+/// A representation of an Exercism exercise document, containing solution files, test files, and related metadata.
 public struct ExerciseDocument: Sendable {
+    /// The root directory of the exercise.
     public var directory: URL
+
+    /// A list of URLs pointing to the solution files within the exercise directory.
     public var solutions: [URL] = []
+
+    /// A list of URLs pointing to the test files within the exercise directory.
     public var tests: [URL] = []
+
+    /// The URL pointing to the exercise's README file, which contains instructions.
     public var instructions: URL? = nil
+
+    /// The solution file associated with the exercise.
     public let solution: SolutionFile
 
-    public init(exerciseDirectory: URL, solution: SolutionFile) throws {
+    /// Initializes the exercise document with the provided exercise directory and solution file.
+    ///
+    /// - Parameters:
+    ///   - exerciseDirectory: The directory containing the exercise files.
+    ///   - solution: The solution file associated with the exercise.
+    /// - Throws: An error if the exercise configuration cannot be loaded or if URLs cannot be created.
+    public init(with exerciseDirectory: URL, solution: SolutionFile) throws {
         self.solution = solution
-        directory = exerciseDirectory
-        let configDir = exerciseDirectory.appendingPathComponent(".exercism/config.json")
-        var config: ExerciseConfig?
-        config = try ExerciseDocument.decodeConfig(configDir)
+        self.directory = exerciseDirectory
 
-        guard let config = config else { return }
-        solutions = config.files.solution.map { s in
-            URL(string: s, relativeTo: directory)!
-        }
-        tests = config.files.test.map { s in
-            URL(string: s, relativeTo: directory)!
-        }
-        instructions = directory.appendingPathComponent("README.md")
+        let configURL = exerciseDirectory.appendingPathComponent(".exercism/config.json")
+        let config = try ExerciseDocument.decodeConfig(for: configURL)
+
+        self.solutions = try ExerciseDocument.makeURLs(from: config.files.solution, relativeTo: directory)
+        self.tests = try ExerciseDocument.makeURLs(from: config.files.test, relativeTo: directory)
+        self.instructions = directory.appendingPathComponent("README.md")
     }
 
-    static func decodeConfig(_ url: URL) throws -> ExerciseConfig {
+    /// Converts a list of file paths to absolute URLs, relative to a given directory.
+    /// - Parameters:
+    ///   - paths: The list of file paths.
+    ///   - directory: The base directory.
+    /// - Throws: `URLError` if any URL is invalid.
+    /// - Returns: An array of valid URLs.
+    private static func makeURLs(from paths: [String], relativeTo directory: URL) throws -> [URL] {
+        return try paths.map { path in
+            guard let url = URL(string: path, relativeTo: directory) else {
+                throw ExercismClientError.genericError(URLError(.badURL))
+            }
+            return url
+        }
+    }
+
+    /// Decodes the exercise configuration from a JSON file located at the provided URL.
+    ///
+    /// When a solution file is fetched, it contains a `.exercism/config.json` directory with the exercise configuration
+    ///
+    /// - Parameter url: The URL pointing to the JSON configuration file.
+    /// - Throws: An error if the data cannot be loaded or decoded.
+    /// - Returns: An `ExerciseConfig` instance parsed from the JSON file.
+    static private func decodeConfig(for url: URL) throws -> ExerciseConfig {
         let data = try Data(contentsOf: url)
-        let config =  try JSONDecoder().decode(ExerciseConfig.self, from: data)
-        return config
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return try decoder.decode(ExerciseConfig.self, from: data)
     }
 }

--- a/Sources/ExercismSwift/Models/ExerciseMetadata.swift
+++ b/Sources/ExercismSwift/Models/ExerciseMetadata.swift
@@ -12,10 +12,4 @@ public struct ExerciseMetadata: Codable {
     public let handle: String
     public let isRequester: Bool
     public let autoApprove: Bool
-
-    private enum CodingKeys: String, CodingKey {
-        case track, exercise, id, url, handle
-        case isRequester = "is_requester"
-        case autoApprove = "auto_approve"
-    }
 }

--- a/Sources/ExercismSwift/Models/InitialFiles.swift
+++ b/Sources/ExercismSwift/Models/InitialFiles.swift
@@ -1,0 +1,12 @@
+//
+//  InitialFiles.swift
+//  ExercismSwift
+//
+//  Created by Angie Mugo on 27/03/2025.
+//
+
+import Foundation
+
+public struct InitialFiles: Decodable {
+    public let files: [SolutionFileData]
+}

--- a/Sources/ExercismSwift/Models/Iteration.swift
+++ b/Sources/ExercismSwift/Models/Iteration.swift
@@ -22,8 +22,4 @@ public struct Iteration: Decodable, Sendable {
 
 public struct SubmitSolutionResponse: Decodable, Sendable {
     public let iteration: Iteration
-
-    enum CodingKeys: String, CodingKey {
-        case iteration
-    }
 }

--- a/Sources/ExercismSwift/Models/Iteration.swift
+++ b/Sources/ExercismSwift/Models/Iteration.swift
@@ -6,7 +6,7 @@ import Foundation
 
 public struct Iteration: Decodable, Sendable {
     public let uuid: String
-    public let submissionUUID: String
+    public let submissionUuid: String
     public let idx: Int
     public let status: IterationStatus
     public let numEssentialAutomatedComments: Int

--- a/Sources/ExercismSwift/Models/Iteration.swift
+++ b/Sources/ExercismSwift/Models/Iteration.swift
@@ -18,22 +18,6 @@ public struct Iteration: Decodable, Sendable {
     public let isPublished: Bool
     public let isLatest: Bool
     public let links: IterationLinks
-
-    enum CodingKeys: String, CodingKey {
-        case uuid
-        case submissionUUID = "submission_uuid"
-        case idx
-        case status
-        case numEssentialAutomatedComments = "num_essential_automated_comments"
-        case numActionableAutomatedComments = "num_actionable_automated_comments"
-        case numNonActionableAutomatedComments = "num_non_actionable_automated_comments"
-        case submissionMethod = "submission_method"
-        case createdAt = "created_at"
-        case testsStatus = "tests_status"
-        case isPublished = "is_published"
-        case isLatest = "is_latest"
-        case links
-    }
 }
 
 public struct SubmitSolutionResponse: Decodable, Sendable {

--- a/Sources/ExercismSwift/Models/IterationLinks.swift
+++ b/Sources/ExercismSwift/Models/IterationLinks.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 public struct IterationLinks: Codable, Sendable {
-    public let selfLink: String
+    public let `self`: String
     public let automatedFeedback: String
     public let delete: String
     public let solution: String

--- a/Sources/ExercismSwift/Models/IterationLinks.swift
+++ b/Sources/ExercismSwift/Models/IterationLinks.swift
@@ -11,13 +11,4 @@ public struct IterationLinks: Codable, Sendable {
     public let solution: String
     public let testRun: String
     public let files: String
-
-    enum CodingKeys: String, CodingKey {
-        case selfLink = "self"
-        case automatedFeedback = "automated_feedback"
-        case delete
-        case solution
-        case testRun = "test_run"
-        case files
-    }
 }

--- a/Sources/ExercismSwift/Models/IterationStatus.swift
+++ b/Sources/ExercismSwift/Models/IterationStatus.swift
@@ -14,4 +14,5 @@ public enum IterationStatus: String, Codable, Sendable {
     case actionableAutomatedFeedback = "actionable_automated_feedback"
     case nonActionableAutomatedFeedback = "non_actionable_automated_feedback"
     case noAutomatedFeedback = "no_automated_feedback"
+    case celebratoryAutomatedFeedback = "celebratory_automated_feedback"
 }

--- a/Sources/ExercismSwift/Models/ResultLink.swift
+++ b/Sources/ExercismSwift/Models/ResultLink.swift
@@ -4,23 +4,8 @@
 
 import Foundation
 
-public struct ResultLink: Sendable {
+public struct ResultLink: Sendable, Codable, Hashable {
     public let `self`: String?
     public let exercises: String?
     public let concepts: String?
-
-    public init(decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.`self` = try! container.decodeIfPresent(String.self, forKey: .`self`) ?? ""
-        exercises = try? container.decodeIfPresent(String.self, forKey: .exercises) ?? ""
-        concepts = try? container.decodeIfPresent(String.self, forKey: .concepts) ?? ""
-    }
-}
-
-extension ResultLink: Codable, Hashable {
-    enum CodingKeys: String, CodingKey {
-        case `self`
-        case exercises
-        case concepts
-    }
 }

--- a/Sources/ExercismSwift/Models/Solution.swift
+++ b/Sources/ExercismSwift/Models/Solution.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-public struct Solution: Sendable {
+public struct Solution: Sendable, Codable, Hashable {
     public let uuid: String
     public let privateUrl: String
     public let publicUrl: String
@@ -24,53 +24,6 @@ public struct Solution: Sendable {
     public let lastIteratedAt: Date?
     public let exercise: BaseInfo
     public let track: BaseInfo
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        uuid = try container.decode(String.self, forKey: .uuid)
-        privateUrl = try container.decode(String.self, forKey: .privateUrl)
-        publicUrl = try container.decode(String.self, forKey: .publicUrl)
-        status = try container.decode(SolutionStatus.self, forKey: .status)
-        mentoringStatus = try container.decode(String.self, forKey: .mentoringStatus)
-        publishedIterationHeadTestsStatus = try container.decode(String.self, forKey: .publishedIterationHeadTestsStatus)
-        hasNotifications = try container.decode(Bool.self, forKey: .hasNotifications)
-        numViews = try container.decode(Int.self, forKey: .numViews)
-        numStars = try container.decode(Int.self, forKey: .numStars)
-        numComments = try container.decode(Int.self, forKey: .numComments)
-        numIterations = try container.decode(Int.self, forKey: .numIterations)
-        numLoc = try container.decode(Int?.self, forKey: .numLoc) ?? 0
-        isOutOfDate = try container.decode(Bool.self, forKey: .isOutOfDate)
-        publishedAt = try? container.decode(Date.self, forKey: .publishedAt)
-        completedAt = try? container.decode(Date.self, forKey: .completedAt)
-        updatedAt = try? container.decode(Date.self, forKey: .updatedAt)
-        lastIteratedAt = try? container.decode(Date.self, forKey: .lastIteratedAt)
-        exercise = try container.decode(BaseInfo.self, forKey: .exercise)
-        track = try container.decode(BaseInfo.self, forKey: .track)
-    }
-}
-
-extension Solution: Codable, Hashable {
-    enum CodingKeys: String, CodingKey {
-        case uuid
-        case privateUrl = "private_url"
-        case publicUrl = "public_url"
-        case status
-        case mentoringStatus = "mentoring_status"
-        case publishedIterationHeadTestsStatus = "published_iteration_head_tests_status"
-        case hasNotifications = "has_notifications"
-        case numViews = "num_views"
-        case numStars = "num_stars"
-        case numComments = "num_comments"
-        case numIterations = "num_iterations"
-        case numLoc = "num_loc"
-        case isOutOfDate = "is_out_of_date"
-        case publishedAt = "published_at"
-        case completedAt = "completed_at"
-        case updatedAt = "updated_at"
-        case lastIteratedAt = "last_iterated_at"
-        case exercise
-        case track
-    }
 }
 
 public enum SolutionStatus: String, Codable, Sendable {

--- a/Sources/ExercismSwift/Models/Solution.swift
+++ b/Sources/ExercismSwift/Models/Solution.swift
@@ -16,7 +16,7 @@ public struct Solution: Sendable, Codable, Hashable {
     public let numStars: Int
     public let numComments: Int
     public let numIterations: Int
-    public let numLoc: Int
+    public let numLoc: Int?
     public let isOutOfDate: Bool
     public let publishedAt: Date?
     public let completedAt: Date?

--- a/Sources/ExercismSwift/Models/SolutionExercise.swift
+++ b/Sources/ExercismSwift/Models/SolutionExercise.swift
@@ -7,11 +7,17 @@ import Foundation
 public struct SolutionExercise: Sendable, Decodable {
     public let id: String
     public let instructionsUrl: String
-    public let trackId: String
-    public let trackLanguage: String
+    public let track: SolutionTrack
+    public var trackLanguage: String {
+        return track.language
+    }
+
+    public var trackId: String {
+        return track.id
+    }
 }
 
-enum SolutionExerciseTrackKeys: String, CodingKey {
-    case id
-    case language
+public struct SolutionTrack: Decodable {
+    public let id: String
+    public let language: String
 }

--- a/Sources/ExercismSwift/Models/SolutionExercise.swift
+++ b/Sources/ExercismSwift/Models/SolutionExercise.swift
@@ -17,7 +17,7 @@ public struct SolutionExercise: Sendable, Decodable {
     }
 }
 
-public struct SolutionTrack: Decodable {
+public struct SolutionTrack: Decodable, Sendable {
     public let id: String
     public let language: String
 }

--- a/Sources/ExercismSwift/Models/SolutionExercise.swift
+++ b/Sources/ExercismSwift/Models/SolutionExercise.swift
@@ -4,28 +4,11 @@
 
 import Foundation
 
-public struct SolutionExercise: Sendable {
+public struct SolutionExercise: Sendable, Decodable {
     public let id: String
     public let instructionsUrl: String
     public let trackId: String
     public let trackLanguage: String
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        id = try container.decode(String.self, forKey: .id)
-        instructionsUrl = try container.decode(String.self, forKey: .instructionsUrl)
-        let trackContainer = try container.nestedContainer(keyedBy: SolutionExerciseTrackKeys.self, forKey: .track)
-        trackId = try trackContainer.decode(String.self, forKey: .id)
-        trackLanguage = try trackContainer.decode(String.self, forKey: .language)
-    }
-}
-
-extension SolutionExercise: Decodable {
-    enum CodingKeys: String, CodingKey {
-        case id
-        case instructionsUrl = "instructions_url"
-        case track
-    }
 }
 
 enum SolutionExerciseTrackKeys: String, CodingKey {

--- a/Sources/ExercismSwift/Models/SolutionFile.swift
+++ b/Sources/ExercismSwift/Models/SolutionFile.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-public struct SolutionFile: Sendable {
+public struct SolutionFile: Decodable, Sendable {
     public let id: String
     public let url: String
     public let exercise: SolutionExercise
@@ -12,35 +12,27 @@ public struct SolutionFile: Sendable {
     public let files: [String]
     public let submittedAt: Date?
 
-    enum SolutionKeys: String, CodingKey {
-        case id
-        case url
-        case exercise
+    private enum CodingKeys: String, CodingKey {
+        case id, url, exercise, files, submission
         case fileDownloadBaseUrl = "file_download_base_url"
-        case files
-        case submission
     }
 
-    enum SubmissionKeys: String, CodingKey {
+    private enum SubmissionKeys: String, CodingKey {
         case submittedAt = "submitted_at"
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        let solutionContainer = try container.nestedContainer(keyedBy: SolutionKeys.self, forKey: .solution)
-        id = try solutionContainer.decode(String.self, forKey: .id)
-        url = try solutionContainer.decode(String.self, forKey: .url)
-        fileDownloadBaseUrl = try solutionContainer.decode(String.self, forKey: .fileDownloadBaseUrl)
-        files = try solutionContainer.decode([String].self, forKey: .files)
-        exercise = try solutionContainer.decode(SolutionExercise.self, forKey: .exercise)
-        let submissionContainer = try? solutionContainer.nestedContainer(keyedBy: SubmissionKeys.self, forKey: .submission)
+        id = try container.decode(String.self, forKey: .id)
+        url = try container.decode(String.self, forKey: .url)
+        fileDownloadBaseUrl = try container.decode(String.self, forKey: .fileDownloadBaseUrl)
+        files = try container.decode([String].self, forKey: .files)
+        exercise = try container.decode(SolutionExercise.self, forKey: .exercise)
+
+        // Handle nested submission key
+        let submissionContainer = try? container.nestedContainer(keyedBy: SubmissionKeys.self, forKey: .submission)
         submittedAt = try? submissionContainer?.decode(Date.self, forKey: .submittedAt)
     }
 }
 
-extension SolutionFile: Decodable {
-    enum CodingKeys: String, CodingKey {
-        case solution
-    }
-}
 

--- a/Sources/ExercismSwift/Models/SolutionFile.swift
+++ b/Sources/ExercismSwift/Models/SolutionFile.swift
@@ -11,28 +11,8 @@ public struct SolutionFile: Decodable, Sendable {
     public let fileDownloadBaseUrl: String
     public let files: [String]
     public let submittedAt: Date?
-
-    private enum CodingKeys: String, CodingKey {
-        case id, url, exercise, files, submission
-        case fileDownloadBaseUrl = "file_download_base_url"
-    }
-
-    private enum SubmissionKeys: String, CodingKey {
-        case submittedAt = "submitted_at"
-    }
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        id = try container.decode(String.self, forKey: .id)
-        url = try container.decode(String.self, forKey: .url)
-        fileDownloadBaseUrl = try container.decode(String.self, forKey: .fileDownloadBaseUrl)
-        files = try container.decode([String].self, forKey: .files)
-        exercise = try container.decode(SolutionExercise.self, forKey: .exercise)
-
-        // Handle nested submission key
-        let submissionContainer = try? container.nestedContainer(keyedBy: SubmissionKeys.self, forKey: .submission)
-        submittedAt = try? submissionContainer?.decode(Date.self, forKey: .submittedAt)
-    }
 }
 
-
+struct SolutionResponse: Decodable {
+    public let solution: SolutionFile
+}

--- a/Sources/ExercismSwift/Models/SolutionFileData.swift
+++ b/Sources/ExercismSwift/Models/SolutionFileData.swift
@@ -11,8 +11,11 @@ public struct SolutionFileData: Codable, Sendable {
     public let type: String
     public let digest: String?
 
-    public init(fileName: String, content: String, type: SolutionFileType = SolutionFileType.exercise, digest: String? = nil) {
-        filename = fileName
+    public init(fileName: String,
+                content: String,
+                type: SolutionFileType = SolutionFileType.exercise,
+                digest: String? = nil) {
+        self.filename = fileName
         self.content = content
         self.type = type.rawValue
         self.digest = digest

--- a/Sources/ExercismSwift/Models/SolutionFileData.swift
+++ b/Sources/ExercismSwift/Models/SolutionFileData.swift
@@ -5,17 +5,24 @@
 
 import Foundation
 
-public struct SolutionFileData: Encodable, Sendable {
+public struct SolutionFileData: Codable, Sendable {
     public let filename: String
     public let content: String
-    public let type: SolutionFileType
+    public let type: String
     public let digest: String?
 
     public init(fileName: String, content: String, type: SolutionFileType = SolutionFileType.exercise, digest: String? = nil) {
         filename = fileName
         self.content = content
-        self.type = type
+        self.type = type.rawValue
         self.digest = digest
     }
-}
 
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.filename = try container.decode(String.self, forKey: .filename)
+        self.content = try container.decode(String.self, forKey: .content)
+        self.type = try container.decode(String.self, forKey: .type)
+        self.digest = try container.decodeIfPresent(String.self, forKey: .digest)
+    }
+}

--- a/Sources/ExercismSwift/Models/SolutionFileData.swift
+++ b/Sources/ExercismSwift/Models/SolutionFileData.swift
@@ -20,12 +20,4 @@ public struct SolutionFileData: Codable, Sendable {
         self.type = type.rawValue
         self.digest = digest
     }
-
-    public init(from decoder: any Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.filename = try container.decode(String.self, forKey: .filename)
-        self.content = try container.decode(String.self, forKey: .content)
-        self.type = try container.decode(String.self, forKey: .type)
-        self.digest = try container.decodeIfPresent(String.self, forKey: .digest)
-    }
 }

--- a/Sources/ExercismSwift/Models/SolutionFileType.swift
+++ b/Sources/ExercismSwift/Models/SolutionFileType.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-public enum SolutionFileType: Encodable, Sendable {
+public enum SolutionFileType: String, Codable, Sendable {
     case exercise
     case solution
     case legacy

--- a/Sources/ExercismSwift/Models/SubmissionLinks.swift
+++ b/Sources/ExercismSwift/Models/SubmissionLinks.swift
@@ -10,21 +10,4 @@ public struct SubmissionLinks: Codable, Sendable, Hashable {
     public let testRun: String
     public let initialFiles: String
     public let lastIterationFiles: String
-
-    enum CodingKeys: String, CodingKey {
-        case cancel
-        case submit
-        case testRun = "test_run"
-        case initialFiles = "initial_files"
-        case lastIterationFiles = "last_iteration_files"
-    }
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        cancel = try container.decode(String.self, forKey: .cancel)
-        submit = try container.decode(String.self, forKey: .submit)
-        testRun = try container.decode(String.self, forKey: .testRun)
-        initialFiles = try container.decode(String.self, forKey: .initialFiles)
-        lastIterationFiles = try container.decode(String.self, forKey: .lastIterationFiles)
-    }
 }

--- a/Sources/ExercismSwift/Models/Test.swift
+++ b/Sources/ExercismSwift/Models/Test.swift
@@ -15,35 +15,6 @@ public struct Test: Decodable, Sendable {
     public let outputHtml: String?
     public let taskId: Int?
     public let index: Int?
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        name = try container.decode(String.self, forKey: .name)
-        status = try container.decode(TestStatus.self, forKey: .status)
-        testCode = try? container.decode(String.self, forKey: .testCode)
-        message = try? container.decode(String.self, forKey: .message)
-        messageHtml = try? container.decode(String.self, forKey: .messageHtml)
-        expected = try? container.decode(String.self, forKey: .expected)
-        output = try? container.decode(String.self, forKey: .output)
-        outputHtml = try? container.decode(String.self, forKey: .outputHtml)
-        taskId = try? container.decodeIfPresent(Int.self, forKey: .taskId)
-        index = try? container.decodeIfPresent(Int.self, forKey: .index)
-    }
-}
-
-extension Test {
-    enum CodingKeys: String, CodingKey {
-        case name
-        case status
-        case testCode = "test_code"
-        case message
-        case messageHtml = "message_html"
-        case expected
-        case output
-        case outputHtml = "output_html"
-        case taskId = "task_id"
-        case index
-    }
 }
 
 public enum TestStatus: String, Decodable, Sendable {

--- a/Sources/ExercismSwift/Models/TestRun.swift
+++ b/Sources/ExercismSwift/Models/TestRun.swift
@@ -17,19 +17,4 @@ public struct TestRun: Decodable, Sendable {
     public let tasks: [ExercismTask]
     public let highlightjsLanguage: String
     public let links: ResultLink
-
-    private enum CodingKeys: String, CodingKey {
-        case uuid
-        case submissionUuid = "submission_uuid"
-        case version
-        case status
-        case message
-        case messageHtml = "message_html"
-        case output
-        case outputHtml = "output_html"
-        case tests
-        case tasks
-        case highlightjsLanguage = "highlightjs_language"
-        case links
-    }
 }

--- a/Sources/ExercismSwift/Models/TestRunner.swift
+++ b/Sources/ExercismSwift/Models/TestRunner.swift
@@ -7,19 +7,6 @@ import Foundation
 public struct TestRunner: Decodable, Sendable {
     public let averageTestDuration: Int
     public let status: TestRunnerStatus?
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        averageTestDuration = try container.decode(Int.self, forKey: .averageTestDuration)
-        status = try container.decodeIfPresent(TestRunnerStatus.self, forKey: .status)
-    }
-}
-
-extension TestRunner {
-    enum CodingKeys: String, CodingKey {
-        case averageTestDuration = "average_test_duration"
-        case status
-    }
 }
 
 public struct TestRunnerStatus: Decodable, Sendable {

--- a/Sources/ExercismSwift/Models/TestSubmission.swift
+++ b/Sources/ExercismSwift/Models/TestSubmission.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 
+// TODO: is this necessary? where do we call encodable for this 
 public struct TestSubmission: Codable, Sendable, Hashable {
     public let uuid: String
     public let testsStatus: SubmissionTestsStatus

--- a/Sources/ExercismSwift/Models/TestSubmission.swift
+++ b/Sources/ExercismSwift/Models/TestSubmission.swift
@@ -4,45 +4,23 @@
 
 import Foundation
 
-// TODO: is this necessary? where do we call encodable for this 
 public struct TestSubmission: Codable, Sendable, Hashable {
-    public let uuid: String
-    public let testsStatus: SubmissionTestsStatus
-    public let links: SubmissionLinks
+    public let submission: SubmissionData
 
-    private enum CodingKeys: String, CodingKey {
-        case submission
+    public var testStatus: SubmissionTestsStatus {
+        return submission.testsStatus
     }
 
-    private enum SubmissionKeys: String, CodingKey {
-        case uuid
-        case testsStatus = "tests_status"
-        case links
-    }
-
-    public init(uuid: String, testsStatus: SubmissionTestsStatus, links: SubmissionLinks) {
-        self.uuid = uuid
-        self.testsStatus = testsStatus
-        self.links = links
-    }
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        let submissionContainer = try container.nestedContainer(keyedBy: SubmissionKeys.self, forKey: .submission)
-        uuid = try submissionContainer.decode(String.self, forKey: .uuid)
-        testsStatus = try submissionContainer.decode(SubmissionTestsStatus.self, forKey: .testsStatus)
-        links = try submissionContainer.decode(SubmissionLinks.self, forKey: .links)
-    }
-
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        var submissionContainer = container.nestedContainer(keyedBy: SubmissionKeys.self, forKey: .submission)
-        try submissionContainer.encode(uuid, forKey: .uuid)
-        try submissionContainer.encode(testsStatus, forKey: .testsStatus)
-        try submissionContainer.encode(links, forKey: .links)
+    public var links: SubmissionLinks {
+        return submission.links
     }
 }
 
+public struct SubmissionData: Codable, Sendable, Hashable {
+    public let uuid: String
+    public let testsStatus: SubmissionTestsStatus
+    public let links: SubmissionLinks
+}
 
 public enum SubmissionTestsStatus: String, Codable, Sendable, Hashable {
     case notQueued = "not_queued"

--- a/Sources/ExercismSwift/Models/Track.swift
+++ b/Sources/ExercismSwift/Models/Track.swift
@@ -4,7 +4,6 @@
 
 import Foundation
 
-// TODO: is this necessary? where do we call encodable for this
 public struct Track: Sendable, Codable, Hashable, Identifiable {
     public let slug: String
     public let title: String

--- a/Sources/ExercismSwift/Models/Track.swift
+++ b/Sources/ExercismSwift/Models/Track.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 // TODO: is this necessary? where do we call encodable for this
-public struct Track: Sendable {
+public struct Track: Sendable, Codable, Hashable, Identifiable {
     public let slug: String
     public let title: String
     public let course: Bool
@@ -17,74 +17,33 @@ public struct Track: Sendable {
     public let lastTouchedAt: Date?
     public let isNew: Bool
     public let links: ResultLink?
-    public let isJoined: Bool
-    public let numLearntConcepts: Int
-    public let numCompletedExercises: Int
-    public let numSolutions: Int
-    public let hasNotifications: Bool
-}
-
-extension Track: Codable, Hashable, Identifiable {
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        slug = try container.decode(String.self, forKey: .slug)
-        title = try container.decode(String.self, forKey: .title)
-        course = try container.decode(Bool.self, forKey: .course)
-        numExercises = try container.decode(Int.self, forKey: .numExercises)
-        numConcepts = try container.decode(Int.self, forKey: .numConcepts)
-        webUrl = try container.decode(String.self, forKey: .webUrl)
-        iconUrl = try container.decode(String.self, forKey: .iconUrl)
-        tags = try container.decode(Array.self, forKey: .tags)
-        lastTouchedAt = try? container.decode(Date.self, forKey: .lastTouchedAt)
-        isNew = try container.decode(Bool.self, forKey: .isNew)
-        links = try container.decodeIfPresent(ResultLink.self, forKey: .links)
-        isJoined = try container.decodeIfPresent(Bool.self, forKey: .isJoined) ?? false
-        numLearntConcepts = try container.decodeIfPresent(Int.self, forKey: .numLearntConcepts) ?? 0
-        numCompletedExercises = try container.decodeIfPresent(Int.self, forKey: .numCompletedExercises) ?? 0
-        numSolutions = try container.decodeIfPresent(Int.self, forKey: .numSolutions) ?? 0
-        hasNotifications = try container.decodeIfPresent(Bool.self, forKey: .hasNotifications) ?? false
-    }
-
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-
-        try container.encode(slug, forKey: .slug)
-        try container.encode(title, forKey: .title)
-        try container.encode(course, forKey: .course)
-        try container.encode(numExercises , forKey: .numExercises)
-        try container.encode(numConcepts, forKey: .numConcepts)
-        try container.encode(webUrl, forKey: .webUrl)
-        try container.encode(iconUrl, forKey: .iconUrl)
-        try container.encode(tags, forKey: .tags)
-        try container.encodeIfPresent(lastTouchedAt, forKey: .lastTouchedAt)
-        try container.encode(isNew, forKey: .isNew)
-        try container.encodeIfPresent(links, forKey: .links)
-        try container.encode(isJoined, forKey: .isJoined)
-        try container.encode(numLearntConcepts, forKey: .numLearntConcepts)
-        try container.encode(numSolutions, forKey: .numSolutions)
-        try container.encode(hasNotifications, forKey: .hasNotifications)
-    }
+    let isJoined: Bool?
+    let numLearntConcepts: Int?
+    let numCompletedExercises: Int?
+    let numSolutions: Int?
+    let hasNotifications: Bool?
 
     public var id: String {
         slug
     }
 
-    enum CodingKeys: String, CodingKey {
-        case slug
-        case title
-        case course
-        case numExercises = "num_exercises"
-        case numConcepts = "num_concepts"
-        case webUrl = "web_url"
-        case iconUrl = "icon_url"
-        case tags
-        case lastTouchedAt = "last_touched_at"
-        case isNew = "is_new"
-        case links
-        case isJoined = "is_joined"
-        case numLearntConcepts = "num_learnt_concepts"
-        case numCompletedExercises = "num_completed_exercises"
-        case numSolutions = "num_solutions"
-        case hasNotifications = "has_notifications"
+    public var _isJoined: Bool {
+        return isJoined ?? false
+    }
+
+    public var _numLearntConcepts: Int {
+        return numLearntConcepts ?? 0
+    }
+
+    public var _hasNotifications: Bool {
+        return hasNotifications ?? false
+    }
+
+    public var _numSolutions: Int {
+        return numSolutions ?? 0
+    }
+
+    public var _numCompletedExercises: Int {
+        return numCompletedExercises ?? 0
     }
 }

--- a/Sources/ExercismSwift/Models/Track.swift
+++ b/Sources/ExercismSwift/Models/Track.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 
+// TODO: is this necessary? where do we call encodable for this
 public struct Track: Sendable {
     public let slug: String
     public let title: String

--- a/Sources/ExercismSwift/Network/DateFormatter+ISO8601Full.swift
+++ b/Sources/ExercismSwift/Network/DateFormatter+ISO8601Full.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 extension DateFormatter {
-    public static let iso8601Full: DateFormatter = {
+    static let iso8601Full: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ"
         formatter.calendar = Calendar(identifier: .iso8601)
@@ -10,7 +10,7 @@ extension DateFormatter {
         return formatter
     }()
 
-    public static let iso8601DateOnly: DateFormatter = {
+    static let iso8601DateOnly: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd"
         formatter.calendar = Calendar(identifier: .iso8601)

--- a/Sources/ExercismSwift/Network/NetworkClient.swift
+++ b/Sources/ExercismSwift/Network/NetworkClient.swift
@@ -15,56 +15,89 @@ public enum Network {
     }
 }
 
+/// A protocol defining a network client for making HTTP requests.
+///
+/// Conforming types should implement methods for performing common HTTP operations such as GET, POST, PATCH, DELETE, and downloading files.
 public protocol NetworkClient: AnyObject {
+
+    /// A dictionary of HTTP headers that will be included in all requests.
     var headers: Network.HTTPHeaders { get }
 
-    func get<R: Decodable>(
-        _ url: URL,
-        headers: Network.HTTPHeaders?,
-        completed: @escaping (Result<R, ExercismClientError>) -> Void
-    )
+    /// Performs an HTTP GET request.
+    /// - Parameters:
+    ///   - url: The URL to send the request to.
+    ///   - headers: Optional additional headers to include in the request.
+    ///   - completed: A closure returning a `Result` with a decoded response or an error.
+    func get<R: Decodable>(from url: URL,
+                           headers: Network.HTTPHeaders?,
+                           completed: @escaping (Result<R, ExercismClientError>) -> Void )
 
-    func post<T: Encodable, R: Decodable>(
-        _ url: URL,
-        body: T,
-        headers: Network.HTTPHeaders?,
-        completed: @escaping (Result<R, ExercismClientError>) -> Void
-    )
+    /// Performs an HTTP POST request.
+    /// - Parameters:
+    ///   - url: The URL to send the request to.
+    ///   - body: The request body, encoded as JSON.
+    ///   - headers: Optional additional headers to include in the request.
+    ///   - completed: A closure returning a `Result` with a decoded response or an error.
+    func post<T: Encodable, R: Decodable>(to url: URL,
+                                          body: T,
+                                          headers: Network.HTTPHeaders?,
+                                          completed: @escaping (Result<R, ExercismClientError>) -> Void)
 
-    func patch<T: Encodable, R: Decodable>(
-        _ url: URL,
-        body: T,
-        headers: Network.HTTPHeaders?,
-        completed: @escaping (Result<R, ExercismClientError>) -> Void
-    )
+    /// Performs an HTTP PATCH request.
+    /// - Parameters:
+    ///   - url: The URL to send the request to.
+    ///   - body: The request body, encoded as JSON.
+    ///   - headers: Optional additional headers to include in the request.
+    ///   - completed: A closure returning a `Result` with a decoded response or an error.
+    func patch<T: Encodable, R: Decodable>(to url: URL,
+                                           body: T,
+                                           headers: Network.HTTPHeaders?,
+                                           completed: @escaping (Result<R, ExercismClientError>) -> Void)
 
-    func delete<T: Encodable, R: Decodable>(
-        _ url: URL,
-        body: T,
-        headers: Network.HTTPHeaders?,
-        completed: @escaping (Result<R, ExercismClientError>) -> Void
-    )
+    /// Performs an HTTP DELETE request with a request body.
+    /// - Parameters:
+    ///   - url: The URL to send the request to.
+    ///   - body: The request body, encoded as JSON.
+    ///   - headers: Optional additional headers to include in the request.
+    ///   - completed: A closure returning a `Result` with a decoded response or an error.
+    func delete<T: Encodable, R: Decodable>(from url: URL,
+                                            body: T,
+                                            headers: Network.HTTPHeaders?,
+                                            completed: @escaping (Result<R, ExercismClientError>) -> Void)
 
-    func delete<R: Decodable>(
-        _ url: URL,
-        headers: Network.HTTPHeaders?,
-        completed: @escaping (Result<R, ExercismClientError>) -> Void
-    )
 
-    func download(
-        from sourcePath: URL,
-        to destPath: URL,
-        headers: Network.HTTPHeaders?,
-        completed: @escaping (Result<URL, ExercismClientError>) -> Void
-    )
+    /// Downloads a file from a given URL and saves it to a specified destination.
+    /// - Parameters:
+    ///   - sourcePath: The URL of the file to download.
+    ///   - destPath: The local file URL where the downloaded file should be saved.
+    ///   - headers: Optional additional headers to include in the request.
+    ///   - completed: A closure returning a `Result` with the local file URL or an error.
+    func download(from sourcePath: URL,
+                  to destPath: URL,
+                  headers: Network.HTTPHeaders?,
+                  completed: @escaping (Result<URL, ExercismClientError>) -> Void)
 }
 
+/// This is the  default implementation of a network client that handles HTTP requests and responses.
+///
+/// Supports GET, POST, PATCH, DELETE, and file download operations.
 public class DefaultNetworkClient: NetworkClient {
+    /// JSON encoder used to encode request bodies.
     private let encoder: JSONEncoder
+
+    /// JSON decoder used to decode responses.
     private let decoder: JSONDecoder
+
+    /// Default HTTP headers included in all requests.
     private let defaultHeaders: Network.HTTPHeaders
+
+    /// User-Agent string sent with all requests.
+    ///
+    /// A User-Agent is a string that web browsers and HTTP clients send in their requests to identify themselves to the server. It typically includes information about the software making the request, such as its name, version, and operating system. In this case this is the App using the API
     private let userAgent = "Exercism macOS"
 
+    /// Initializes a network client with optional API token authentication.
+    /// - Parameter apiToken: An optional API token for authorization.
     public init(_ apiToken: String? = nil) {
 
         encoder = JSONEncoder()
@@ -72,6 +105,7 @@ public class DefaultNetworkClient: NetworkClient {
 
         decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(DateFormatter.iso8601Full)
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
         var headers = [
             "User-Agent": userAgent,
         ]
@@ -81,27 +115,34 @@ public class DefaultNetworkClient: NetworkClient {
         defaultHeaders = headers
     }
 
+    /// Returns the default HTTP headers used for requests.
     public var headers: Network.HTTPHeaders {
         defaultHeaders
     }
 
-    public func get<R: Decodable>(
-        _ url: URL,
-        headers: Network.HTTPHeaders? = nil,
-        completed: @escaping (Result<R, ExercismClientError>) -> Void
-    ) {
-
+    /// Performs a GET request to the specified URL.
+    /// - Parameters:
+    ///   - url: The target URL for the request.
+    ///   - headers: Optional custom headers for the request.
+    ///   - completed: A completion handler returning a `Result` containing the decoded response or an error.
+    public func get<R: Decodable>(from url: URL,
+                                  headers: Network.HTTPHeaders? = nil,
+                                  completed: @escaping (Result<R, ExercismClientError>) -> Void) {
         let request = buildRequest(method: .GET, url: url, headers: headers)
         print(request.url?.absoluteURL ?? "")
         executeRequest(request: request, completed: completed)
     }
 
-    public func post<T: Encodable, R: Decodable>(
-        _ url: URL,
-        body: T,
-        headers: Network.HTTPHeaders? = nil,
-        completed: @escaping (Result<R, ExercismClientError>) -> Void
-    ) {
+    /// Performs a POST request with a request body.
+    /// - Parameters:
+    ///   - url: The target URL for the request.
+    ///   - body: The request body to be sent.
+    ///   - headers: Optional custom headers.
+    ///   - completed: A completion handler returning a `Result` containing the decoded response or an error.
+    public func post<T: Encodable, R: Decodable>(to url: URL,
+                                                 body: T,
+                                                 headers: Network.HTTPHeaders? = nil,
+                                                 completed: @escaping (Result<R, ExercismClientError>) -> Void) {
         var request = buildRequest(method: .POST, url: url, headers: headers)
         let requestBody: Data
 
@@ -118,13 +159,46 @@ public class DefaultNetworkClient: NetworkClient {
         executeRequest(request: request, completed: completed)
     }
 
+    /// Performs a PATCH request with a request body.
+    /// - Parameters:
+    ///   - url: The target URL for the request.
+    ///   - body: The request body to be sent.
+    ///   - headers: Optional custom headers.
+    ///   - completed: A completion handler returning a `Result` containing the decoded response or an error.
     public func patch<T: Encodable, R: Decodable>(
-        _ url: URL,
+        to url: URL,
         body: T,
         headers: Network.HTTPHeaders? = nil,
-        completed: @escaping (Result<R, ExercismClientError>) -> Void
-    ) {
-        var request = buildRequest(method: .PATCH, url: url, headers: headers)
+        completed: @escaping (Result<R, ExercismClientError>) -> Void) {
+            var request = buildRequest(method: .PATCH, url: url, headers: headers)
+            let requestBody: Data
+
+            do {
+                requestBody = try encoder.encode(body)
+            } catch {
+                completed(.failure(.bodyEncodingError(error)))
+                return
+            }
+
+            DebugEnvironment.log.trace("BODY:\n " + String(data: requestBody, encoding: .utf8)!)
+
+            request.httpBody = requestBody
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+            executeRequest(request: request, completed: completed)
+        }
+
+    /// Performs a DELETE request with an optional request body.
+    /// - Parameters:
+    ///   - url: The target URL for the request.
+    ///   - body: An optional request body to be sent.
+    ///   - headers: Optional custom headers.
+    ///   - completed: A completion handler returning a `Result` containing the decoded response or an error.
+    public func delete<R: Decodable, T: Encodable>(from url: URL,
+                                                   body: T,
+                                                   headers: Network.HTTPHeaders? = nil,
+                                                   completed: @escaping (Result<R, ExercismClientError>) -> Void) {
+        var request = buildRequest(method: .DELETE, url: url, headers: headers)
         let requestBody: Data
 
         do {
@@ -142,89 +216,61 @@ public class DefaultNetworkClient: NetworkClient {
         executeRequest(request: request, completed: completed)
     }
 
-    public func delete<R: Decodable>(
-        _ url: URL,
-        headers: Network.HTTPHeaders? = nil,
-        completed: @escaping (Result<R, ExercismClientError>) -> Void
-    ) {
-        // swiftlint:disable:next syntactic_sugar
-        self.genericDelete(url, body: Optional<Int>.none, headers: headers, completed: completed)
-    }
-
-    public func delete<T: Encodable, R: Decodable>(
-        _ url: URL,
-        body: T,
-        headers: Network.HTTPHeaders? = nil,
-        completed: @escaping (Result<R, ExercismClientError>) -> Void
-    ) {
-        self.genericDelete(url, body: body, headers: headers, completed: completed)
-    }
-
-    public func download(
-        from sourcePath: URL,
+    /// Downloads a file from a specified URL and saves it to the given destination path.
+    ///
+    /// - If successful, if the file exists locally, it is replaced; otherwise, it is created. The completion handler is updated with the destination path
+    /// - Parameters:
+    ///   - sourcePath: The URL to download the file from.
+    ///   - destPath: The destination URL where the file should be saved.
+    ///   - headers: Optional custom headers.
+    ///   - completed: A completion handler returning a `Result` containing the file URL or an error.
+    public func download(from sourcePath: URL,
         to destPath: URL,
         headers: Network.HTTPHeaders? = [:],
-        completed: @escaping (Result<URL, ExercismClientError>) -> Void
-    ) {
+        completed: @escaping (Result<URL, ExercismClientError>) -> Void) {
         let request = initRequest(url: sourcePath, headers: headers)
 
-        let task = URLSession.shared.downloadTask(with: request) { url, response, error in
-            var completeResult: Result<URL, ExercismClientError>?
-
+        let task = URLSession.shared.downloadTask(with: request) { tempURL, response, error in
             if let error = NetworkClientHelpers.extractError(response: response, error: error) {
-                completeResult = .failure(error)
-            } else if let url = url {
-                DebugEnvironment.log.trace(url.description)
-                do {
-                    if FileManager.default.fileExists(atPath: destPath.relativePath) {
-                        _ = try FileManager.default.replaceItemAt(destPath, withItemAt: url)
-                    } else {
-                        try FileManager.default.moveItem(at: url, to: destPath)
-                    }
-                    completeResult = .success(destPath)
-                } catch {
-                    completeResult = .failure(.genericError(error))
+                DispatchQueue.main.async {
+                    completed(.failure(error))
                 }
-            } else {
-                completeResult = .failure(.unsupportedResponseError)
-            }
-
-            DispatchQueue.main.async {
-                guard let completeResult = completeResult else {
-                    fatalError("Something is wrong, no result!")
-                }
-                completed(completeResult)
-            }
-        }
-        task.resume()
-    }
-
-    private func genericDelete<T: Encodable, R: Decodable>(
-        _ url: URL,
-        body: T?,
-        headers: Network.HTTPHeaders?,
-        completed: @escaping (Result<R, ExercismClientError>) -> Void
-    ) {
-        var request = buildRequest(method: .DELETE, url: url, headers: headers)
-        if let body = body {
-            let requestBody: Data
-
-            do {
-                requestBody = try encoder.encode(body)
-            } catch {
-                completed(.failure(.bodyEncodingError(error)))
                 return
             }
 
-            DebugEnvironment.log.trace("BODY:\n " + String(data: requestBody, encoding: .utf8)!)
+            guard let tempURL = tempURL else {
+                DispatchQueue.main.async {
+                    completed(.failure(.unsupportedResponseError))
+                }
+                return
+            }
 
-            request.httpBody = requestBody
+            DebugEnvironment.log.trace("Downloaded file location: \(tempURL)")
+
+            do {
+                if FileManager.default.fileExists(atPath: destPath.relativePath) {
+                    try FileManager.default.removeItem(at: destPath)
+                }
+                try FileManager.default.moveItem(at: tempURL, to: destPath)
+                DispatchQueue.main.async {
+                    completed(.success(destPath))
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    completed(.failure(.genericError(error)))
+                }
+            }
         }
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
-        executeRequest(request: request, completed: completed)
+        task.resume()
     }
 
+    /// Builds a URL request with the specified HTTP method and headers.
+    /// - Parameters:
+    ///   - method: A  `HTTPMethod` type
+    ///   - url: A `URL` type created from base url and path
+    ///   - headers: The headers associated with the request
+    /// - Returns: A `URLRequest` type
     private func initRequest(url: URL, headers: Network.HTTPHeaders? = [:]) -> URLRequest {
         let allHeaders = defaultHeaders.merging(headers ?? [:]) { (_, new) in
             new
@@ -237,31 +283,48 @@ public class DefaultNetworkClient: NetworkClient {
         return request
     }
 
-    private func buildRequest(
-        method: Network.HTTPMethod,
-        url: URL,
-        headers: Network.HTTPHeaders?
-    ) -> URLRequest {
+    /// Builds a URL request with the specified HTTP method and headers.
+    /// - Parameters:
+    ///   - method: A  `HTTPMethod` type
+    ///   - url: A `URL` type created from base url and path
+    ///   - headers: The headers associated with the request
+    /// - Returns: A `URLRequest` type
+    private func buildRequest(method: Network.HTTPMethod,
+                              url: URL,
+                              headers: Network.HTTPHeaders?) -> URLRequest {
         var request = initRequest(url: url, headers: headers)
         request.httpMethod = method.rawValue
 
         return request
     }
 
-    private func executeRequest<T: Decodable>(
-        request: URLRequest,
-        completed: @escaping (Result<T, ExercismClientError>) -> Void
-    ) {
+    /// Executes a network request, processes the response, and decodes it into the specified type.
+    ///
+    /// - The method sends an HTTP request using `URLSession.shared.dataTask(with:)`.
+    /// - It checks for errors using `NetworkClientHelpers.extractError(data:response:error:)` and returns a failure if an error is found.
+    /// - If the request succeeds and data is received, it attempts to decode the data into the specified type `T: Decodable`.
+    /// - If decoding fails, it captures and returns a `.decodingError` or a `.genericError`.
+    /// - The result is returned asynchronously on the main thread via the `completed` closure.
+    ///
+    /// - Parameters:
+    ///   - request: The `URLRequest` to be executed.
+    ///   - completed: A completion handler returning a `Result<T, ExercismClientError>`,
+    ///     where `T` is the expected response type if decoding succeeds, or an error otherwise.
+    private func executeRequest<T: Decodable>(request: URLRequest,
+                                              completed: @escaping (Result<T, ExercismClientError>) -> Void) {
         DebugEnvironment.log.debug("Request: \(request.httpMethod ?? "") \(request.url?.absoluteString ?? "")")
+
         let task = URLSession.shared.dataTask(with: request) { data, response, error in
             var completeResult: Result<T, ExercismClientError>?
 
+            // Extract error if any exists
             if let error = NetworkClientHelpers.extractError(data: data, response: response, error: error) {
                 completeResult = .failure(error)
-            } else if let data = data {
+            }
+            // If no error, attempt to decode response data
+            else if let data = data {
                 DebugEnvironment.log.trace(String(data: data, encoding: .utf8) ?? "")
                 do {
-                    DebugEnvironment.log.trace(String(data: data, encoding: .utf8) ?? "")
                     let result = try self.decoder.decode(T.self, from: data)
                     completeResult = .success(result)
                 } catch let decodingError as Swift.DecodingError {
@@ -269,17 +332,22 @@ public class DefaultNetworkClient: NetworkClient {
                 } catch {
                     completeResult = .failure(.genericError(error))
                 }
-            } else {
+            }
+            // If no data and no specific error, return an unsupported response error
+            else {
                 completeResult = .failure(.unsupportedResponseError)
             }
 
+            // Ensure the completion handler is executed on the main thread
             DispatchQueue.main.async {
                 guard let completeResult = completeResult else {
-                    fatalError("Something is wrong, no result!")
+                    fatalError("Unexpected state: No result available!")
                 }
                 completed(completeResult)
             }
         }
+
         task.resume()
     }
+
 }

--- a/Sources/ExercismSwift/Network/NetworkClient.swift
+++ b/Sources/ExercismSwift/Network/NetworkClient.swift
@@ -165,28 +165,27 @@ public class DefaultNetworkClient: NetworkClient {
     ///   - body: The request body to be sent.
     ///   - headers: Optional custom headers.
     ///   - completed: A completion handler returning a `Result` containing the decoded response or an error.
-    public func patch<T: Encodable, R: Decodable>(
-        to url: URL,
-        body: T,
-        headers: Network.HTTPHeaders? = nil,
-        completed: @escaping (Result<R, ExercismClientError>) -> Void) {
-            var request = buildRequest(method: .PATCH, url: url, headers: headers)
-            let requestBody: Data
+    public func patch<T: Encodable, R: Decodable>(to url: URL,
+                                                  body: T,
+                                                  headers: Network.HTTPHeaders? = nil,
+                                                  completed: @escaping (Result<R, ExercismClientError>) -> Void) {
+        var request = buildRequest(method: .PATCH, url: url, headers: headers)
+        let requestBody: Data
 
-            do {
-                requestBody = try encoder.encode(body)
-            } catch {
-                completed(.failure(.bodyEncodingError(error)))
-                return
-            }
-
-            DebugEnvironment.log.trace("BODY:\n " + String(data: requestBody, encoding: .utf8)!)
-
-            request.httpBody = requestBody
-            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-
-            executeRequest(request: request, completed: completed)
+        do {
+            requestBody = try encoder.encode(body)
+        } catch {
+            completed(.failure(.bodyEncodingError(error)))
+            return
         }
+
+        DebugEnvironment.log.trace("BODY:\n " + String(data: requestBody, encoding: .utf8)!)
+
+        request.httpBody = requestBody
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        executeRequest(request: request, completed: completed)
+    }
 
     /// Performs a DELETE request with an optional request body.
     /// - Parameters:
@@ -225,9 +224,9 @@ public class DefaultNetworkClient: NetworkClient {
     ///   - headers: Optional custom headers.
     ///   - completed: A completion handler returning a `Result` containing the file URL or an error.
     public func download(from sourcePath: URL,
-        to destPath: URL,
-        headers: Network.HTTPHeaders? = [:],
-        completed: @escaping (Result<URL, ExercismClientError>) -> Void) {
+                         to destPath: URL,
+                         headers: Network.HTTPHeaders? = [:],
+                         completed: @escaping (Result<URL, ExercismClientError>) -> Void) {
         let request = initRequest(url: sourcePath, headers: headers)
 
         let task = URLSession.shared.downloadTask(with: request) { tempURL, response, error in

--- a/Sources/ExercismSwift/Network/NetworkClient.swift
+++ b/Sources/ExercismSwift/Network/NetworkClient.swift
@@ -81,7 +81,7 @@ public protocol NetworkClient: AnyObject {
 /// This is the  default implementation of a network client that handles HTTP requests and responses.
 ///
 /// Supports GET, POST, PATCH, DELETE, and file download operations.
-public class DefaultNetworkClient: NetworkClient {
+ class DefaultNetworkClient: NetworkClient {
     /// JSON encoder used to encode request bodies.
     private let encoder: JSONEncoder
 
@@ -98,7 +98,7 @@ public class DefaultNetworkClient: NetworkClient {
 
     /// Initializes a network client with optional API token authentication.
     /// - Parameter apiToken: An optional API token for authorization.
-    public init(_ apiToken: String? = nil) {
+    init(_ apiToken: String? = nil) {
 
         encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .formatted(DateFormatter.iso8601Full)
@@ -116,7 +116,7 @@ public class DefaultNetworkClient: NetworkClient {
     }
 
     /// Returns the default HTTP headers used for requests.
-    public var headers: Network.HTTPHeaders {
+    var headers: Network.HTTPHeaders {
         defaultHeaders
     }
 
@@ -125,7 +125,7 @@ public class DefaultNetworkClient: NetworkClient {
     ///   - url: The target URL for the request.
     ///   - headers: Optional custom headers for the request.
     ///   - completed: A completion handler returning a `Result` containing the decoded response or an error.
-    public func get<R: Decodable>(from url: URL,
+    func get<R: Decodable>(from url: URL,
                                   headers: Network.HTTPHeaders? = nil,
                                   completed: @escaping (Result<R, ExercismClientError>) -> Void) {
         let request = buildRequest(method: .GET, url: url, headers: headers)
@@ -139,7 +139,7 @@ public class DefaultNetworkClient: NetworkClient {
     ///   - body: The request body to be sent.
     ///   - headers: Optional custom headers.
     ///   - completed: A completion handler returning a `Result` containing the decoded response or an error.
-    public func post<T: Encodable, R: Decodable>(to url: URL,
+    func post<T: Encodable, R: Decodable>(to url: URL,
                                                  body: T,
                                                  headers: Network.HTTPHeaders? = nil,
                                                  completed: @escaping (Result<R, ExercismClientError>) -> Void) {
@@ -165,7 +165,7 @@ public class DefaultNetworkClient: NetworkClient {
     ///   - body: The request body to be sent.
     ///   - headers: Optional custom headers.
     ///   - completed: A completion handler returning a `Result` containing the decoded response or an error.
-    public func patch<T: Encodable, R: Decodable>(to url: URL,
+    func patch<T: Encodable, R: Decodable>(to url: URL,
                                                   body: T,
                                                   headers: Network.HTTPHeaders? = nil,
                                                   completed: @escaping (Result<R, ExercismClientError>) -> Void) {
@@ -193,7 +193,7 @@ public class DefaultNetworkClient: NetworkClient {
     ///   - body: An optional request body to be sent.
     ///   - headers: Optional custom headers.
     ///   - completed: A completion handler returning a `Result` containing the decoded response or an error.
-    public func delete<R: Decodable, T: Encodable>(from url: URL,
+    func delete<R: Decodable, T: Encodable>(from url: URL,
                                                    body: T,
                                                    headers: Network.HTTPHeaders? = nil,
                                                    completed: @escaping (Result<R, ExercismClientError>) -> Void) {
@@ -223,7 +223,7 @@ public class DefaultNetworkClient: NetworkClient {
     ///   - destPath: The destination URL where the file should be saved.
     ///   - headers: Optional custom headers.
     ///   - completed: A completion handler returning a `Result` containing the file URL or an error.
-    public func download(from sourcePath: URL,
+    func download(from sourcePath: URL,
                          to destPath: URL,
                          headers: Network.HTTPHeaders? = [:],
                          completed: @escaping (Result<URL, ExercismClientError>) -> Void) {

--- a/Sources/ExercismSwift/Network/NetworkClientHelpers.swift
+++ b/Sources/ExercismSwift/Network/NetworkClientHelpers.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 /// A helper utility for handling network errors in the Exercism API client.
-public enum NetworkClientHelpers {
-
+enum NetworkClientHelpers {
+    
     /// Determines and extracts an `ExercismClientError` from the given network response.
     ///
     /// - If a network-related error is provided, it wraps it as a `genericError`.
@@ -14,16 +14,16 @@ public enum NetworkClientHelpers {
     ///   - response: The URL response received from the server.
     ///   - error: Any network-related error encountered.
     /// - Returns: An `ExercismClientError` if an error is detected, otherwise `nil`.
-    public static func extractError(data: Data?,
-                                    response: URLResponse?,
-                                    error: Error?) -> ExercismClientError? {
+    static func extractError(data: Data?,
+                             response: URLResponse?,
+                             error: Error?) -> ExercismClientError? {
         if let error = error {
             return .genericError(error)
         }
-
+        
         return extractError(data: data, response: response)
     }
-
+    
     /// Parses the HTTP response and extracts an `ExercismClientError` if an error is detected.
     /// - If the response status code is between 400 and 502, it attempts to decode the error response and extract an error message.
     /// - If decoding fails, it returns a generic HTTP error with the response status code.
@@ -38,7 +38,7 @@ public enum NetworkClientHelpers {
         guard let response = response as? HTTPURLResponse else {
             return .unsupportedResponseError
         }
-
+        
         if (400..<503).contains(response.statusCode) {
             if let data = data {
                 if let err = try? JSONDecoder().decode(ErrorResponse.self, from: data) {
@@ -52,10 +52,10 @@ public enum NetworkClientHelpers {
                 return .genericError(Network.Errors.HTTPError(code: response.statusCode))
             }
         }
-
+        
         return nil
     }
-
+    
     /// Analyzes the HTTP response and error to determine if an `ExercismClientError` should be returned.
     /// - If a network-related error is provided, it wraps it as a `genericError`.
     /// - If the response is missing or invalid, it returns an `unsupportedResponseError`.
@@ -65,20 +65,20 @@ public enum NetworkClientHelpers {
     ///   - response: The URL response received from the server.
     ///   - error: Any network-related error encountered.
     /// - Returns: An `ExercismClientError` if an error is detected, otherwise `nil`.
-    public static func extractError(response: URLResponse?,
-                                    error: Error?) -> ExercismClientError? {
+    static func extractError(response: URLResponse?,
+                             error: Error?) -> ExercismClientError? {
         if let error = error {
             return .genericError(error)
         }
-
+        
         guard let response = response as? HTTPURLResponse else {
             return .unsupportedResponseError
         }
-
+        
         if (400..<503).contains(response.statusCode) {
             return .genericError(Network.Errors.HTTPError(code: response.statusCode))
         }
-
+        
         return nil
     }
 }

--- a/Sources/ExercismSwift/Network/NetworkClientHelpers.swift
+++ b/Sources/ExercismSwift/Network/NetworkClientHelpers.swift
@@ -1,7 +1,22 @@
 import Foundation
 
+/// A helper utility for handling network errors in the Exercism API client.
 public enum NetworkClientHelpers {
-    public static func extractError(data: Data?, response: URLResponse?, error: Error?) -> ExercismClientError? {
+
+    /// Determines and extracts an `ExercismClientError` from the given network response.
+    ///
+    /// - If a network-related error is provided, it wraps it as a `genericError`.
+    /// - Otherwise, it delegates error extraction to `extractError(data:response:)`,
+    ///   which inspects the response status code and decodes error messages if available.
+    ///
+    /// - Parameters:
+    ///   - data: The response data from the network request, if available.
+    ///   - response: The URL response received from the server.
+    ///   - error: Any network-related error encountered.
+    /// - Returns: An `ExercismClientError` if an error is detected, otherwise `nil`.
+    public static func extractError(data: Data?,
+                                    response: URLResponse?,
+                                    error: Error?) -> ExercismClientError? {
         if let error = error {
             return .genericError(error)
         }
@@ -9,7 +24,17 @@ public enum NetworkClientHelpers {
         return extractError(data: data, response: response)
     }
 
-    public static func extractError(data: Data?, response: URLResponse?) -> ExercismClientError? {
+    /// Parses the HTTP response and extracts an `ExercismClientError` if an error is detected.
+    /// - If the response status code is between 400 and 502, it attempts to decode the error response and extract an error message.
+    /// - If decoding fails, it returns a generic HTTP error with the response status code.
+    /// - If no response is available, it returns an `unsupportedResponseError`.
+    ///
+    /// - Parameters:
+    ///   - data: The response data from the network request, if available.
+    ///   - response: The URL response received from the server.
+    /// - Returns: An `ExercismClientError` if an error is detected, otherwise `nil`.
+    private static func extractError(data: Data?,
+                                     response: URLResponse?) -> ExercismClientError? {
         guard let response = response as? HTTPURLResponse else {
             return .unsupportedResponseError
         }
@@ -17,7 +42,9 @@ public enum NetworkClientHelpers {
         if (400..<503).contains(response.statusCode) {
             if let data = data {
                 if let err = try? JSONDecoder().decode(ErrorResponse.self, from: data) {
-                    return .apiError(code: ExercismErrorCode(rawValue: err.error.type) ?? .genericError, type: err.error.type, message: err.error.message)
+                    return .apiError(code: ExercismErrorCode(rawValue: err.error.type) ?? .genericError,
+                                     type: err.error.type,
+                                     message: err.error.message)
                 } else {
                     return .genericError(Network.Errors.HTTPError(code: response.statusCode))
                 }
@@ -29,7 +56,17 @@ public enum NetworkClientHelpers {
         return nil
     }
 
-    public static func extractError(response: URLResponse?, error: Error?) -> ExercismClientError? {
+    /// Analyzes the HTTP response and error to determine if an `ExercismClientError` should be returned.
+    /// - If a network-related error is provided, it wraps it as a `genericError`.
+    /// - If the response is missing or invalid, it returns an `unsupportedResponseError`.
+    /// - If the response status code is between 400 and 502, it returns a `genericError` with the corresponding HTTP status code.
+    ///
+    /// - Parameters:
+    ///   - response: The URL response received from the server.
+    ///   - error: Any network-related error encountered.
+    /// - Returns: An `ExercismClientError` if an error is detected, otherwise `nil`.
+    public static func extractError(response: URLResponse?,
+                                    error: Error?) -> ExercismClientError? {
         if let error = error {
             return .genericError(error)
         }
@@ -43,6 +80,5 @@ public enum NetworkClientHelpers {
         }
 
         return nil
-
     }
 }

--- a/Sources/ExercismSwift/Network/URLBuilder.swift
+++ b/Sources/ExercismSwift/Network/URLBuilder.swift
@@ -1,10 +1,10 @@
 import Foundation
 
 /// A utility class for constructing URLs for the Exercism API.
-public class URLBuilder {
+class URLBuilder {
     /// The base URL for all network requests.
     let base = Network.exercismBaseURL
-
+    
     /// Constructs a URL by replacing the `{identifier}` placeholder in the given path with the provided entity identifier.
     ///
     /// - Parameters:
@@ -13,18 +13,17 @@ public class URLBuilder {
     ///   - params: Optional query parameters to be appended to the URL.
     /// - Returns: A fully constructed `URL`.
     /// - Note: This method will terminate execution if the URL cannot be formed.
-    public func url<T>(
-        for path: ExercismClientPath,
-        identifier: EntityIdentifier<T, String>,
-        params: [String: String] = [:]) -> URL {
-            let newPath = path.rawValue.replacingOccurrences(of: "{identifier}", with: identifier.rawValue)
-            guard let url = URL(string: newPath, relativeTo: base) else {
-                fatalError("Invalid path, unable to create a URL: \(path)")
-            }
-
-            return buildURL(from: url, params: params)
+    func url<T>(for path: ExercismClientPath,
+                identifier: EntityIdentifier<T, String>,
+                params: [String: String] = [:]) -> URL {
+        let newPath = path.rawValue.replacingOccurrences(of: "{identifier}", with: identifier.rawValue)
+        guard let url = URL(string: newPath, relativeTo: base) else {
+            fatalError("Invalid path, unable to create a URL: \(path)")
         }
-
+        
+        return buildURL(from: url, params: params)
+    }
+    
     /// Constructs a URL by formatting the given path with optional arguments and appending query parameters.
     ///
     /// - Parameters:
@@ -33,17 +32,17 @@ public class URLBuilder {
     ///   - urlArgs: Variadic arguments used to format the path string.
     /// - Returns: A fully constructed `URL`.
     /// - Note: This method will terminate execution if the URL cannot be formed.
-    public func url(for path: ExercismClientPath,
-                    params: [String: String] = [:],
-                    urlArgs: CVarArg...) -> URL {
+    func url(for path: ExercismClientPath,
+             params: [String: String] = [:],
+             urlArgs: CVarArg...) -> URL {
         let path = String(format: path.rawValue, arguments: urlArgs)
         guard let url = URL(string: path, relativeTo: base) else {
             fatalError("Invalid path, unable to create a URL: \(path)")
         }
-
+        
         return buildURL(from: url, params: params)
     }
-
+    
     /// Appends query parameters to a given URL.
     ///
     /// - Parameters:
@@ -55,17 +54,17 @@ public class URLBuilder {
         guard var components = URLComponents(url: url, resolvingAgainstBaseURL: true) else {
             fatalError("Invalid URL, unable to build components path")
         }
-
+        
         if !params.isEmpty {
             components.queryItems = params.map {
                 URLQueryItem(name: $0.key, value: $0.value)
             }
         }
-
+        
         guard let result = components.url else {
             fatalError("Unable to create URL from components (\(components))")
         }
-
+        
         return result
     }
 }

--- a/Sources/ExercismSwift/Network/URLBuilder.swift
+++ b/Sources/ExercismSwift/Network/URLBuilder.swift
@@ -1,41 +1,59 @@
 import Foundation
 
+/// A utility class for constructing URLs for the Exercism API.
 public class URLBuilder {
-    let base: URL
+    /// The base URL for all network requests.
+    let base = Network.exercismBaseURL
 
-    init() {
-        base = Network.exercismBaseURL
-    }
-
+    /// Constructs a URL by replacing the `{identifier}` placeholder in the given path with the provided entity identifier.
+    ///
+    /// - Parameters:
+    ///   - path: The `ExercismClientPath` representing the endpoint path.
+    ///   - identifier: The entity identifier used to replace `{identifier}` in the path.
+    ///   - params: Optional query parameters to be appended to the URL.
+    /// - Returns: A fully constructed `URL`.
+    /// - Note: This method will terminate execution if the URL cannot be formed.
     public func url<T>(
-            path: ExercismClientPath,
-            identifier: EntityIdentifier<T, String>,
-            params: [String: String] = [:]
-    ) -> URL {
-        let newPath = path.rawValue.replacingOccurrences(of: "{identifier}", with: identifier.rawValue)
-        guard let url = URL(string: newPath, relativeTo: base) else {
-            fatalError("Invalid path, unable to create a URL: \(path)")
+        for path: ExercismClientPath,
+        identifier: EntityIdentifier<T, String>,
+        params: [String: String] = [:]) -> URL {
+            let newPath = path.rawValue.replacingOccurrences(of: "{identifier}", with: identifier.rawValue)
+            guard let url = URL(string: newPath, relativeTo: base) else {
+                fatalError("Invalid path, unable to create a URL: \(path)")
+            }
+
+            return buildURL(from: url, params: params)
         }
 
-        return buildURL(url: url, params: params)
-    }
-
-    public func url(
-            path: ExercismClientPath,
-            params: [String: String] = [:],
-            urlArgs: CVarArg...
-    ) -> URL {
+    /// Constructs a URL by formatting the given path with optional arguments and appending query parameters.
+    ///
+    /// - Parameters:
+    ///   - path: The `ExercismClientPath` representing the endpoint path.
+    ///   - params: Optional query parameters to be appended to the URL.
+    ///   - urlArgs: Variadic arguments used to format the path string.
+    /// - Returns: A fully constructed `URL`.
+    /// - Note: This method will terminate execution if the URL cannot be formed.
+    public func url(for path: ExercismClientPath,
+                    params: [String: String] = [:],
+                    urlArgs: CVarArg...) -> URL {
         let path = String(format: path.rawValue, arguments: urlArgs)
         guard let url = URL(string: path, relativeTo: base) else {
             fatalError("Invalid path, unable to create a URL: \(path)")
         }
 
-        return buildURL(url: url, params: params)
+        return buildURL(from: url, params: params)
     }
 
-    private func buildURL(url: URL, params: [String: String]) -> URL {
+    /// Appends query parameters to a given URL.
+    ///
+    /// - Parameters:
+    ///   - url: The base `URL` to which query parameters should be added.
+    ///   - params: A dictionary of query parameters as key-value pairs.
+    /// - Returns: A `URL` with the query parameters appended.
+    /// - Note: This method will terminate execution if the URL components cannot be resolved.
+    private func buildURL(from url: URL, params: [String: String]) -> URL {
         guard var components = URLComponents(url: url, resolvingAgainstBaseURL: true) else {
-            fatalError("Invalid url, unable to build components path")
+            fatalError("Invalid URL, unable to build components path")
         }
 
         if !params.isEmpty {
@@ -43,10 +61,12 @@ public class URLBuilder {
                 URLQueryItem(name: $0.key, value: $0.value)
             }
         }
+
         guard let result = components.url else {
-            fatalError("Unable to create url from components (\(components)")
+            fatalError("Unable to create URL from components (\(components))")
         }
 
         return result
     }
 }
+

--- a/Sources/ExercismSwift/Responses/ListMeta.swift
+++ b/Sources/ExercismSwift/Responses/ListMeta.swift
@@ -4,23 +4,8 @@
 
 import Foundation
 
-public struct ListMeta {
+public struct ListMeta: Decodable {
     public let currentPage: Int
     public let totalCount: Int
     public let totalPages: Int
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        currentPage = try container.decode(Int.self, forKey: .currentPage)
-        totalCount = try container.decode(Int.self, forKey: .totalCount)
-        totalPages = try container.decode(Int.self, forKey: .totalPages)
-    }
-}
-
-extension ListMeta: Decodable {
-    enum CodingKeys: String, CodingKey {
-        case currentPage = "current_page"
-        case totalCount = "total_count"
-        case totalPages = "total_pages"
-    }
 }

--- a/Sources/ExercismSwift/Responses/TestRunResponse.swift
+++ b/Sources/ExercismSwift/Responses/TestRunResponse.swift
@@ -7,9 +7,4 @@ import Foundation
 public struct TestRunResponse: Decodable, Sendable {
     public let testRun: TestRun?
     public let testRunner: TestRunner
-
-    enum CodingKeys: String, CodingKey {
-        case testRun = "test_run"
-        case testRunner = "test_runner"
-    }
 }

--- a/Sources/ExercismSwift/Responses/ValidateTokenResponse.swift
+++ b/Sources/ExercismSwift/Responses/ValidateTokenResponse.swift
@@ -4,28 +4,15 @@
 
 import Foundation
 
-public struct ValidateTokenResponse {
-    public let status: TokenStatus
+public struct ValidateTokenResponse: Decodable {
+    public let status: StatusWrapper
 
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        let rawStatus = try container.decode([String: String].self, forKey: .status)
-        let token = rawStatus.first(where: { $0.key == "token" })
-        if token?.value == "valid" {
-            status = .valid
-        } else {
-            status = .invalid
-        }
+    public struct StatusWrapper: Decodable {
+        public let token: TokenStatus
     }
 }
 
-public enum TokenStatus {
+public enum TokenStatus: String, Decodable {
     case valid
     case invalid
-}
-
-extension ValidateTokenResponse: Decodable {
-    enum CodingKeys: String, CodingKey {
-        case status
-    }
 }


### PR DESCRIPTION
- Add DocC documentation 
- Remove manual decoding and conform to `decodable` or `codable` 
- Add access control - only have public in objects that need to be exposed to the client that will use them 
- Fix log access so that when app is in debug, the logs are shown to simplify debugging 