### PR TITLE
Ft/convert to async

### DIFF
--- a/Sources/ExercismSwift/Common/SolutionManager.swift
+++ b/Sources/ExercismSwift/Common/SolutionManager.swift
@@ -4,115 +4,99 @@
 
 import Foundation
 
-/// A manager responsible for handling solution file downloads and organization.
+/// A manager responsible for downloading and organizing solution files locally.
 class SolutionManager {
-    /// The `SolutionFile` downloaded from  `downloadSolution`
+
+    /// The solution metadata containing file paths and download information.
     let solution: SolutionFile
 
-    /// The network client used for downloading files.
+    /// The network client used to download files.
     let client: NetworkClient
 
-    /// The file manager responsible for handling file operations.
+    /// The file manager used to manage local file system operations.
     let fileManager: FileManager
 
     /// Initializes a new `SolutionManager` instance.
     ///
     /// - Parameters:
-    ///   - solution: The `SolutionFile` containing file details.
-    ///   - client: The `NetworkClient` used for downloading solution files.
-    ///   - fileManager: The `FileManager` instance for handling local file operations. Defaults to `FileManager.default`.
-    init(with solution: SolutionFile,
-         client: NetworkClient,
-         fileManager: FileManager = FileManager.default) {
+    ///   - solution: The `SolutionFile` describing the exercise and associated files.
+    ///   - client: The `NetworkClient` used for downloading the files.
+    ///   - fileManager: A custom `FileManager` for managing file paths (defaults to `.default`).
+    init(
+        with solution: SolutionFile,
+        client: NetworkClient,
+        fileManager: FileManager = .default
+    ) {
         self.solution = solution
         self.client = client
         self.fileManager = fileManager
     }
 
-    /// Downloads all solution files to a local directory.
+    /// Downloads all solution files and stores them in a local directory.
     ///
-    /// - Parameter completed: A closure that returns the local directory URL or an error.
-    ///
-    /// - Note: This method creates the required directory structure before downloading files.
-    func download(_ completed: @escaping (URL?, ExercismClientError?) -> Void) {
-        let dispatchGroup = DispatchGroup()
-        var error: ExercismClientError?
+    /// - Returns: The URL of the local directory containing the downloaded files.
+    /// - Throws: An `ExercismClientError` if the directory creation or download fails.
+    func download() async throws(ExercismClientError) -> URL {
+        let solutionDir = try getOrCreateSolutionDir()
 
-        do {
-            let solutionDir = try getOrCreateSolutionDir()
+        for file in solution.files {
+            var components = file.split(separator: "/")
+            guard let fileName = components.popLast()?.description else {
+                throw ExercismClientError.builderError(message: "Invalid file name in path: \(file)")
+            }
 
-            for file in solution.files {
-                dispatchGroup.enter()
-                var fileComponents = file.split(separator: "/")
-                let fileLen = fileComponents.count
-                var destPath = solutionDir
-                guard let fileName = fileComponents.last?.description else {
-                    error = ExercismClientError.builderError(message: "Error creating file name")
-                    return
-                }
-
-                if fileLen > 1 {
-                    fileComponents.removeLast()
-                    destPath = solutionDir
-                        .appendingPathComponent(fileComponents
-                            .joined(separator: "/"), isDirectory: true)
-                    try fileManager.createDirectory(atPath: destPath.path,
-                                                    withIntermediateDirectories: true)
-                }
-
-                downloadFile(at: file,
-                             to: destPath.appendingPathComponent(fileName)) { _ in
-                    dispatchGroup.leave()
+            var destinationDir = solutionDir
+            if !components.isEmpty {
+                destinationDir = solutionDir.appendingPathComponent(components.joined(separator: "/"), isDirectory: true)
+                do {
+                    try fileManager.createDirectory(atPath: destinationDir.path, withIntermediateDirectories: true)
+                } catch {
+                    throw ExercismClientError.builderError(message: "Failed to create local solution directory: \(error.localizedDescription)")
                 }
             }
 
-            dispatchGroup.notify(queue: DispatchQueue.main) {
-                if let error = error {
-                    completed(nil, error)
-                } else {
-                    completed(solutionDir, nil)
-                }
-            }
-        } catch let error {
-            completed(nil, .builderError(message: error.localizedDescription))
-        }
-    }
-
-    /// Retrieves or creates the local directory for storing solution files.
-    ///
-    /// - Returns: The URL of the solution directory.
-    /// - Throws: An error if the directory cannot be created.
-    private func getOrCreateSolutionDir() throws -> URL {
-        let docsFolder = try fileManager.url(for: .documentDirectory,
-                                             in: .userDomainMask,
-                                             appropriateFor: nil,
-                                             create: true)
-
-        let solutionDir = docsFolder
-            .appendingPathComponent("\(solution.exercise.trackId)/\(solution.exercise.id)/", isDirectory: true)
-
-        if !fileManager.fileExists(atPath: solutionDir.relativePath) {
-            try fileManager.createDirectory(atPath: solutionDir.path, withIntermediateDirectories: true)
+            let destinationURL = destinationDir.appendingPathComponent(fileName)
+            _ = try await downloadFile(at: file, to: destinationURL)
         }
 
         return solutionDir
     }
 
-    /// Downloads a single file from the solution's file download URL.
+    /// Ensures the solution directory exists or creates it.
+    ///
+    /// - Returns: The URL of the local solution directory.
+    /// - Throws: An `ExercismClientError` if directory creation fails.
+    private func getOrCreateSolutionDir() throws(ExercismClientError) -> URL {
+        do {
+            let documents = try fileManager.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
+
+            let solutionDir = documents
+                .appendingPathComponent(solution.exercise.trackId)
+                .appendingPathComponent(solution.exercise.id, isDirectory: true)
+
+            if !fileManager.fileExists(atPath: solutionDir.path) {
+                try fileManager.createDirectory(at: solutionDir, withIntermediateDirectories: true)
+            }
+
+            return solutionDir
+        } catch {
+            throw ExercismClientError.builderError(message: "Failed to create local solution directory: \(error.localizedDescription)")
+        }
+    }
+
+    /// Downloads a single file from the provided solution path.
     ///
     /// - Parameters:
-    ///   - path: The file path to download.
-    ///   - destination: The local destination URL for the downloaded file.
-    ///   - completed: A closure that returns a result containing the file URL or an error.
-    private func downloadFile(at path: String,
-                              to destination: URL,
-                              completed: @escaping (Result<URL, ExercismClientError>) -> Void) {
-        let url = URL(string: path,
-                      relativeTo: URL(string: solution.fileDownloadBaseUrl))!
-        client.download(from: url,
-                        to: destination,
-                        headers: [:]) { result in
-            completed(result)
+    ///   - path: The file path relative to the base URL.
+    ///   - destination: The full local file URL to save the file to.
+    /// - Returns: The local file URL after download completes.
+    /// - Throws: An `ExercismClientError` if the download fails.
+    private func downloadFile(at path: String, to destination: URL) async throws(ExercismClientError) -> URL {
+        guard let baseURL = URL(string: solution.fileDownloadBaseUrl),
+              let fileURL = URL(string: path, relativeTo: baseURL) else {
+            throw ExercismClientError.builderError(message: "Invalid download URL for path: \(path)")
         }
+
+        return try await client.download(from: fileURL, to: destination, headers: [:])
     }
 }

--- a/Sources/ExercismSwift/Common/SolutionManager.swift
+++ b/Sources/ExercismSwift/Common/SolutionManager.swift
@@ -5,98 +5,107 @@
 import Foundation
 
 /// A manager responsible for downloading and organizing solution files locally.
-class SolutionManager {
-
+final class SolutionManager {
+    
     /// The solution metadata containing file paths and download information.
     let solution: SolutionFile
-
+    
     /// The network client used to download files.
     let client: NetworkClient
-
+    
     /// The file manager used to manage local file system operations.
     let fileManager: FileManager
-
+    
     /// Initializes a new `SolutionManager` instance.
     ///
     /// - Parameters:
     ///   - solution: The `SolutionFile` describing the exercise and associated files.
     ///   - client: The `NetworkClient` used for downloading the files.
     ///   - fileManager: A custom `FileManager` for managing file paths (defaults to `.default`).
-    init(
-        with solution: SolutionFile,
-        client: NetworkClient,
-        fileManager: FileManager = .default
-    ) {
+    init(with solution: SolutionFile,
+         client: NetworkClient,
+         fileManager: FileManager = .default) {
         self.solution = solution
         self.client = client
         self.fileManager = fileManager
     }
-
+    
     /// Downloads all solution files and stores them in a local directory.
     ///
     /// - Returns: The URL of the local directory containing the downloaded files.
     /// - Throws: An `ExercismClientError` if the directory creation or download fails.
     func download() async throws(ExercismClientError) -> URL {
         let solutionDir = try getOrCreateSolutionDir()
-
-        for file in solution.files {
-            var components = file.split(separator: "/")
-            guard let fileName = components.popLast()?.description else {
-                throw ExercismClientError.builderError(message: "Invalid file name in path: \(file)")
-            }
-
-            var destinationDir = solutionDir
-            if !components.isEmpty {
-                destinationDir = solutionDir.appendingPathComponent(components.joined(separator: "/"), isDirectory: true)
-                do {
-                    try fileManager.createDirectory(atPath: destinationDir.path, withIntermediateDirectories: true)
-                } catch {
-                    throw ExercismClientError.builderError(message: "Failed to create local solution directory: \(error.localizedDescription)")
+        
+        do {
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                for file in solution.files {
+                    group.addTask {
+                        let destinationURL = try self.makeDestinationURL(for: file, in: solutionDir)
+                        _ = try await self.downloadFile(at: file, to: destinationURL)
+                    }
                 }
+                try await group.waitForAll()
             }
-
-            let destinationURL = destinationDir.appendingPathComponent(fileName)
-            _ = try await downloadFile(at: file, to: destinationURL)
+        } catch {
+            if let clientError = error as? ExercismClientError {
+                throw clientError
+            } else {
+                throw ExercismClientError.builderError(message: error.localizedDescription)
+            }
         }
-
+        
         return solutionDir
     }
-
+    
+    /// Resolves the local destination URL for a given relative file path.
+    private func makeDestinationURL(for relativePath: String, in baseDirectory: URL) throws(ExercismClientError) -> URL {
+        let components = relativePath.split(separator: "/").map(String.init)
+        guard let fileName = components.last else {
+            throw ExercismClientError.builderError(message: "Invalid file name in path: \(relativePath)")
+        }
+        
+        let subfolderPath = components.dropLast().joined(separator: "/")
+        let destinationDir = baseDirectory.appendingPathComponent(subfolderPath, isDirectory: true)
+        
+        // Create intermediate directories if needed
+        if !fileManager.fileExists(atPath: destinationDir.path) {
+            do {
+                try fileManager.createDirectory(at: destinationDir, withIntermediateDirectories: true)
+            } catch {
+                throw ExercismClientError.builderError(message: "Could not create directory at \(destinationDir.path): \(error.localizedDescription)")
+            }
+        }
+        
+        return destinationDir.appendingPathComponent(fileName)
+    }
+    
     /// Ensures the solution directory exists or creates it.
-    ///
-    /// - Returns: The URL of the local solution directory.
-    /// - Throws: An `ExercismClientError` if directory creation fails.
     private func getOrCreateSolutionDir() throws(ExercismClientError) -> URL {
         do {
             let documents = try fileManager.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
-
+            
             let solutionDir = documents
                 .appendingPathComponent(solution.exercise.trackId)
                 .appendingPathComponent(solution.exercise.id, isDirectory: true)
-
+            
             if !fileManager.fileExists(atPath: solutionDir.path) {
                 try fileManager.createDirectory(at: solutionDir, withIntermediateDirectories: true)
             }
-
+            
             return solutionDir
         } catch {
-            throw ExercismClientError.builderError(message: "Failed to create local solution directory: \(error.localizedDescription)")
+            throw ExercismClientError.builderError(message: "Failed to create solution directory: \(error.localizedDescription)")
         }
     }
-
-    /// Downloads a single file from the provided solution path.
-    ///
-    /// - Parameters:
-    ///   - path: The file path relative to the base URL.
-    ///   - destination: The full local file URL to save the file to.
-    /// - Returns: The local file URL after download completes.
-    /// - Throws: An `ExercismClientError` if the download fails.
-    private func downloadFile(at path: String, to destination: URL) async throws(ExercismClientError) -> URL {
+    
+    /// Downloads a single file from the solution base URL to the specified destination.
+    private func downloadFile(at relativePath: String, to destination: URL) async throws(ExercismClientError) -> URL {
         guard let baseURL = URL(string: solution.fileDownloadBaseUrl),
-              let fileURL = URL(string: path, relativeTo: baseURL) else {
-            throw ExercismClientError.builderError(message: "Invalid download URL for path: \(path)")
+              let fileURL = URL(string: relativePath, relativeTo: baseURL) else {
+            throw ExercismClientError.builderError(message: "Invalid download URL for: \(relativePath)")
         }
-
+        
         return try await client.download(from: fileURL, to: destination, headers: [:])
     }
 }

--- a/Sources/ExercismSwift/ExercismClient+Badges.swift
+++ b/Sources/ExercismSwift/ExercismClient+Badges.swift
@@ -14,7 +14,7 @@ extension ExercismClient {
     ///
     /// - Returns: A `ListResponse<Badge>` containing the earned badges.
     /// - Throws: An `ExercismClientError` if the request fails or decoding fails.
-    public func badges() async throws -> ListResponse<Badge> {
+    public func badges() async throws(ExercismClientError) -> ListResponse<Badge> {
         try await networkClient.get(from: urlBuilder.url(for: ExercismClientPath.badges,
                                                          params: [:]),
                                     headers: headers())

--- a/Sources/ExercismSwift/ExercismClient+Badges.swift
+++ b/Sources/ExercismSwift/ExercismClient+Badges.swift
@@ -17,6 +17,6 @@ extension ExercismClient {
     public func badges() async throws(ExercismClientError) -> ListResponse<Badge> {
         try await networkClient.get(from: urlBuilder.url(for: ExercismClientPath.badges,
                                                          params: [:]),
-                                    headers: headers())
+                                    headers: headers)
     }
 }

--- a/Sources/ExercismSwift/ExercismClient+Badges.swift
+++ b/Sources/ExercismSwift/ExercismClient+Badges.swift
@@ -12,12 +12,11 @@ import Foundation
 extension ExercismClient {
     /// Fetches the list of badges earned by the user.
     ///
-    /// - Parameter completed: A completion handler that returns a `Result` containing either a `ListResponse<Exercise>` with the earned badges or an `ExercismClientError` if the request fails.
-    public func badges(completed: @escaping (Result<ListResponse<Badge>,
-                                             ExercismClientError>) -> Void) {
-        networkClient.get(from: urlBuilder.url(for: ExercismClientPath.badges,
-                                               params: [:]),
-                          headers: headers(),
-                          completed: completed)
+    /// - Returns: A `ListResponse<Badge>` containing the earned badges.
+    /// - Throws: An `ExercismClientError` if the request fails or decoding fails.
+    public func badges() async throws -> ListResponse<Badge> {
+        try await networkClient.get(from: urlBuilder.url(for: ExercismClientPath.badges,
+                                                         params: [:]),
+                                    headers: headers())
     }
 }

--- a/Sources/ExercismSwift/ExercismClient+Exercises.swift
+++ b/Sources/ExercismSwift/ExercismClient+Exercises.swift
@@ -8,7 +8,7 @@ extension ExercismClient {
     /// - Parameter track: The identifier of the track for which exercises are to be fetched.
     /// - Returns: A `ListResponse<Exercise>` containing the exercises.
     /// - Throws: An `ExercismClientError` if the request fails or decoding fails.
-    public func exercises(for track: String) async throws -> ListResponse<Exercise> {
+    public func exercises(for track: String) async throws(ExercismClientError) -> ListResponse<Exercise> {
         try await networkClient.get(from: urlBuilder.url(for: .exercises, urlArgs: track),
                                     headers: headers())
     }

--- a/Sources/ExercismSwift/ExercismClient+Exercises.swift
+++ b/Sources/ExercismSwift/ExercismClient+Exercises.swift
@@ -10,6 +10,6 @@ extension ExercismClient {
     /// - Throws: An `ExercismClientError` if the request fails or decoding fails.
     public func exercises(for track: String) async throws(ExercismClientError) -> ListResponse<Exercise> {
         try await networkClient.get(from: urlBuilder.url(for: .exercises, urlArgs: track),
-                                    headers: headers())
+                                    headers: headers)
     }
 }

--- a/Sources/ExercismSwift/ExercismClient+Exercises.swift
+++ b/Sources/ExercismSwift/ExercismClient+Exercises.swift
@@ -5,14 +5,11 @@ import Foundation
 extension ExercismClient {
     /// Fetches the list of exercises available for a given track.
     ///
-    /// - Parameters:
-    ///   - track: The identifier of the track for which exercises are to be fetched.
-    ///   - completed: A completion handler that returns a `Result` containing either a `ListResponse<Exercise>` with the exercises or an `ExercismClientError` if the request fails.
-    public func exercises(for track: String,
-                          completed: @escaping (Result<ListResponse<Exercise>, ExercismClientError>) -> Void) {
-        networkClient.get(from: urlBuilder.url(for: .exercises,
-                                               urlArgs: track),
-                          headers: headers(),
-                          completed: completed)
+    /// - Parameter track: The identifier of the track for which exercises are to be fetched.
+    /// - Returns: A `ListResponse<Exercise>` containing the exercises.
+    /// - Throws: An `ExercismClientError` if the request fails or decoding fails.
+    public func exercises(for track: String) async throws -> ListResponse<Exercise> {
+        try await networkClient.get(from: urlBuilder.url(for: .exercises, urlArgs: track),
+                                    headers: headers())
     }
 }

--- a/Sources/ExercismSwift/ExercismClient+Solutions.swift
+++ b/Sources/ExercismSwift/ExercismClient+Solutions.swift
@@ -3,107 +3,88 @@ import Foundation
 // MARK: - Solutions
 
 extension ExercismClient {
-
+    
     /// Fetches solutions for a given track with optional filters.
     ///
     /// - Parameters:
-    ///   - track: The track name associated with the solutions (optional).
-    ///   - status: The status of the solutions to fetch (optional).
-    ///   - mentoringStatus: The mentoring status of the solutions (optional).
-    ///   - completed: A completion handler that returns a `Result` containing either a list of solutions (`ListResponse<Solution>`) or an `ExercismClientError` if the request fails.
+    ///   - track: The track slug associated with the solutions (optional).
+    ///   - status: The solution status filter (optional).
+    ///   - mentoringStatus: The mentoring status filter (optional).
+    /// - Returns: A list of solutions matching the given filters.
+    /// - Throws: `ExercismClientError` if the request fails.
     public func solutions(for track: String? = nil,
                           withStatus status: SolutionStatus? = nil,
-                          mentoringStatus: MentoringStatus? = nil,
-                          completed: @escaping (Result<ListResponse<Solution>,
-                                                ExercismClientError>) -> Void) {
+                          mentoringStatus: MentoringStatus? = nil) async throws -> ListResponse<Solution> {
         var params: [String: String] = [:]
         if let t = track {
             params["track_slug"] = t
         }
-
+        
         if let s = status {
             params["status"] = s.rawValue
         }
-
+        
         if let mt = mentoringStatus {
             params["mentoring_status"] = mt.rawValue
         }
-
-        networkClient.get(from: urlBuilder.url(for: .solutions,
-                                               params: params),
-                          headers: headers(),
-                          completed: completed)
+        
+        return try await networkClient.get(from: urlBuilder.url(for: .solutions,
+                                                                params: params),
+                                           headers: headers())
     }
-
-    /// Fetches the initial solution files for a given solution so that user can revert to the original state of the given exercise.
+    
+    /// Fetches the initial solution files for a given solution ID to allow reverting the exercise to its original state.
+    ///
+    /// - Parameter solutionId: The unique identifier of the solution.
+    /// - Returns: The initial files associated with the solution.
+    /// - Throws: `ExercismClientError` if the request fails.
+    public func initialSolution(for solutionId: String) async throws -> InitialFiles {
+        try await networkClient.get(from: urlBuilder.url(for: .initialFiles,
+                                                         urlArgs: solutionId),
+                                    headers: headers())
+    }
+    
+    /// Downloads the solution files for a given exercise and returns an `ExerciseDocument`.
     ///
     /// - Parameters:
-    ///   - solutionId: The unique identifier of the solution.
-    ///   - completed: A completion handler that returns a `Result` containing either the initial solution files (`InitialFiles`) or an `ExercismClientError` if the request fails.
-    public func initialSolution(for solutionId: String,
-                                completed: @escaping (Result<InitialFiles,
-                                                      ExercismClientError>) -> Void) {
-        networkClient.get(from: urlBuilder.url(for: .initialFiles,
-                                               urlArgs: solutionId),
-                          headers: headers(),
-                          completed: completed)
-    }
-
-    /// Downloads the solution file for a given exercise.
-    ///
-    /// - Parameters:
-    ///   - id: The solution identifier. Defaults to `"latest"`, which fetches the most recent solution.
+    ///   - id: The solution identifier. Defaults to `"latest"` to fetch the most recent solution.
     ///   - track: The track ID to which the exercise belongs.
     ///   - exercise: The exercise ID for which the solution is being downloaded.
-    ///   - completed: A completion handler that returns a `Result` containing either an `ExerciseDocument` if successful or an `ExercismClientError` if the request fails.
+    /// - Returns: An `ExerciseDocument` constructed from the downloaded files.
+    /// - Throws: `ExercismClientError` if the download or document creation fails.
     public func downloadSolution(with id: String = "latest",
                                  for track: String,
-                                 exercise: String,
-                                 completed: @escaping (Result<ExerciseDocument,
-                                                       ExercismClientError>) -> Void) {
-        var params: [String: String] = [:]
-        params["track_id"] = track
-        params["exercise_id"] = exercise
-
-        networkClient.get(from: urlBuilder.url(for: .solutionsFile,
-                                               params: params,
-                                               urlArgs: id),
-                          headers: headers()) { (result: Result<SolutionResponse,
-                                                 ExercismClientError>) in
-            switch result {
-            case .success(let solutionResponse):
-                let solutionManager = SolutionManager(with: solutionResponse.solution,
-                                                      client: self.networkClient)
-                solutionManager.download { url, error in
-                    if let url = url {
-                        do {
-                            let exerciseDocument = try ExerciseDocument(with: url,
-                                                                        solution: solutionResponse.solution)
-                            completed(.success(exerciseDocument))
-                        } catch let error {
-                            completed(.failure(.builderError(message: error.localizedDescription)))
-                        }
-                    }  else {
-                        completed(.failure(.builderError(message: "Error creating exercise directory")))
-                    }
-                }
-
-            case .failure(let error):
-                completed(.failure(error))
-            }
+                                 exercise: String) async throws(ExercismClientError) -> ExerciseDocument {
+        let params: [String: String] = [
+            "track_id": track,
+            "exercise_id": exercise
+        ]
+        
+        let solutionResponse: SolutionResponse = try await networkClient.get(from:
+                                                                                urlBuilder.url(for: .solutionsFile,
+                                                                                               params: params,
+                                                                                               urlArgs: id),
+                                                                             headers: headers())
+        let solutionManager = SolutionManager(with: solutionResponse.solution, client: self.networkClient)
+        
+        let directoryURL: URL = try await solutionManager.download()
+        
+        do {
+            return try ExerciseDocument(with: directoryURL, solution: solutionResponse.solution)
+        } catch {
+            throw ExercismClientError.builderError(message: error.localizedDescription)
         }
     }
-
+    
+    
     /// Fetches the iteration history for a given solution.
     ///
-    /// - Parameters:
-    ///   - solutionId: The unique identifier of the solution.
-    ///   - completed: A completion handler that returns a `Result` containing either an `IterationResponse` if successful or an `ExercismClientError` if the request fails.
-    public func getIterations(for solutionId: String,
-                              completed: @escaping (Result<IterationResponse, ExercismClientError>) -> Void) {
-        networkClient.get(from: urlBuilder.url(for: .iteration,
-                                               urlArgs: solutionId),
-                          headers: headers(),
-                          completed: completed)
+    /// - Parameter solutionId: The unique identifier of the solution.
+    /// - Returns: An `IterationResponse` containing the iteration details.
+    /// - Throws: `ExercismClientError` if the request fails.
+    public func getIterations(for solutionId: String) async throws -> IterationResponse {
+        try await networkClient.get(from: urlBuilder.url(for: .iteration,
+                                                         urlArgs: solutionId),
+                                    headers: headers())
     }
 }

--- a/Sources/ExercismSwift/ExercismClient+Solutions.swift
+++ b/Sources/ExercismSwift/ExercismClient+Solutions.swift
@@ -14,7 +14,7 @@ extension ExercismClient {
     /// - Throws: `ExercismClientError` if the request fails.
     public func solutions(for track: String? = nil,
                           withStatus status: SolutionStatus? = nil,
-                          mentoringStatus: MentoringStatus? = nil) async throws -> ListResponse<Solution> {
+                          mentoringStatus: MentoringStatus? = nil) async throws(ExercismClientError) -> ListResponse<Solution> {
         var params: [String: String] = [:]
         if let t = track {
             params["track_slug"] = t
@@ -38,7 +38,7 @@ extension ExercismClient {
     /// - Parameter solutionId: The unique identifier of the solution.
     /// - Returns: The initial files associated with the solution.
     /// - Throws: `ExercismClientError` if the request fails.
-    public func initialSolution(for solutionId: String) async throws -> InitialFiles {
+    public func initialSolution(for solutionId: String) async throws(ExercismClientError) -> InitialFiles {
         try await networkClient.get(from: urlBuilder.url(for: .initialFiles,
                                                          urlArgs: solutionId),
                                     headers: headers())
@@ -82,7 +82,7 @@ extension ExercismClient {
     /// - Parameter solutionId: The unique identifier of the solution.
     /// - Returns: An `IterationResponse` containing the iteration details.
     /// - Throws: `ExercismClientError` if the request fails.
-    public func getIterations(for solutionId: String) async throws -> IterationResponse {
+    public func getIterations(for solutionId: String) async throws(ExercismClientError) -> IterationResponse {
         try await networkClient.get(from: urlBuilder.url(for: .iteration,
                                                          urlArgs: solutionId),
                                     headers: headers())

--- a/Sources/ExercismSwift/ExercismClient+Solutions.swift
+++ b/Sources/ExercismSwift/ExercismClient+Solutions.swift
@@ -30,7 +30,7 @@ extension ExercismClient {
         
         return try await networkClient.get(from: urlBuilder.url(for: .solutions,
                                                                 params: params),
-                                           headers: headers())
+                                           headers: headers)
     }
     
     /// Fetches the initial solution files for a given solution ID to allow reverting the exercise to its original state.
@@ -41,7 +41,7 @@ extension ExercismClient {
     public func initialSolution(for solutionId: String) async throws(ExercismClientError) -> InitialFiles {
         try await networkClient.get(from: urlBuilder.url(for: .initialFiles,
                                                          urlArgs: solutionId),
-                                    headers: headers())
+                                    headers: headers)
     }
     
     /// Downloads the solution files for a given exercise and returns an `ExerciseDocument`.
@@ -64,7 +64,7 @@ extension ExercismClient {
                                                                                 urlBuilder.url(for: .solutionsFile,
                                                                                                params: params,
                                                                                                urlArgs: id),
-                                                                             headers: headers())
+                                                                             headers: headers)
         let solutionManager = SolutionManager(with: solutionResponse.solution, client: self.networkClient)
         
         let directoryURL: URL = try await solutionManager.download()
@@ -85,6 +85,6 @@ extension ExercismClient {
     public func getIterations(for solutionId: String) async throws(ExercismClientError) -> IterationResponse {
         try await networkClient.get(from: urlBuilder.url(for: .iteration,
                                                          urlArgs: solutionId),
-                                    headers: headers())
+                                    headers: headers)
     }
 }

--- a/Sources/ExercismSwift/ExercismClient+Submissions.swift
+++ b/Sources/ExercismSwift/ExercismClient+Submissions.swift
@@ -19,7 +19,7 @@ extension ExercismClient {
         return try await networkClient.post(to: urlBuilder.url(for: .testSubmission,
                                                                urlArgs: solution),
                                             body: files,
-                                            headers: headers())
+                                            headers: headers)
     }
     
     /// Retrieves the test run status.
@@ -31,7 +31,7 @@ extension ExercismClient {
         guard let url = URL(string: link) else {
             throw ExercismClientError.builderError(message: "Invalid URL")
         }
-        return try await networkClient.get(from: url, headers: headers())
+        return try await networkClient.get(from: url, headers: headers)
     }
     
     /// Cancels an ongoing test run.
@@ -43,7 +43,7 @@ extension ExercismClient {
         guard let url = URL(string: link) else {
             throw ExercismClientError.builderError(message: "Invalid URL")
         }
-        return try await networkClient.get(from: url, headers: headers())
+        return try await networkClient.get(from: url, headers: headers)
     }
     
     /// Submits a solution for review after successfully running and passing all tests.
@@ -55,14 +55,14 @@ extension ExercismClient {
         guard let url = URL(string: link) else {
             throw ExercismClientError.builderError(message: "Invalid URL")
         }
-        return try await networkClient.post(to: url, body: "", headers: headers())
+        return try await networkClient.post(to: url, body: "", headers: headers)
     }
     
     /// Marks a solution as complete, optionally publishing it and specifying an iteration.
     ///
     /// - Parameters:
     ///   - solution: The identifier of the solution to be completed.
-    ///   - publish: A boolean indicating whether to publish the solution (default is `false`).
+    ///   - publish: A boolean indicating whether to publish the solution (defaults to `false`).
     ///   - iteration: An optional iteration number to complete, if applicable.
     /// - Returns: A `CompletedSolution` indicating the result of the completion action.
     /// - Throws: An `ExercismClientError` if the request or decoding fails.
@@ -73,7 +73,7 @@ extension ExercismClient {
         return try await networkClient.patch(to: urlBuilder.url(for: .completeSolution,
                                                                 urlArgs: solution),
                                              body: payload,
-                                             headers: headers())
+                                             headers: headers)
     }
 }
 

--- a/Sources/ExercismSwift/ExercismClient+Submissions.swift
+++ b/Sources/ExercismSwift/ExercismClient+Submissions.swift
@@ -11,81 +11,69 @@ extension ExercismClient {
     /// - Parameters:
     ///   - solution: The identifier of the solution to be tested.
     ///   - contents: A list of `SolutionFileData` representing the file contents used for testing.
-    ///   - completed: A completion handler returning a `Result` with either a `TestSubmission` on success or an `ExercismClientError` on failure.
+    /// - Returns: A `TestSubmission` result from the test run.
+    /// - Throws: An `ExercismClientError` if the request or decoding fails.
     public func runTest(for solution: String,
-                        with contents: [SolutionFileData],
-                        completed: @escaping (Result<TestSubmission, ExercismClientError>) -> Void) {
+                        with contents: [SolutionFileData]) async throws -> TestSubmission {
         let files = SolutionTestFiles(files: contents)
-        networkClient.post(to: urlBuilder.url(for: .testSubmission, urlArgs: solution),
-                           body: files,
-                           headers: headers(),
-                           completed: completed)
+        return try await networkClient.post(to: urlBuilder.url(for: .testSubmission,
+                                                               urlArgs: solution),
+                                            body: files,
+                                            headers: headers())
     }
     
-    /// Retrieves the `TestRunResponse`
+    /// Retrieves the test run status.
     ///
-    /// - Parameters:
-    ///   - link: The URL link to fetch the test run status.
-    ///   - completed: A completion handler returning a `Result` with either a `TestRunResponse` on success or an `ExercismClientError` on failure.
-    public func getTestRun(withLink link: String,
-                           completed: @escaping (Result<TestRunResponse,
-                                                 ExercismClientError>) -> Void) {
-        networkClient.get(from: URL(string: link)!,
-                          headers: headers(),
-                          completed: completed)
+    /// - Parameter link: The URL link to fetch the test run status.
+    /// - Returns: A `TestRunResponse` representing the current status of the test run.
+    /// - Throws: An `ExercismClientError` if the request or decoding fails.
+    public func getTestRun(withLink link: String) async throws -> TestRunResponse {
+        guard let url = URL(string: link) else {
+            throw ExercismClientError.builderError(message: "Invalid URL")
+        }
+        return try await networkClient.get(from: url, headers: headers())
     }
     
     /// Cancels an ongoing test run.
     ///
-    /// - Parameters:
-    ///   - link: The URL link to cancel the test run.
-    ///   - completed: A completion handler returning a `Result` with either a `TestSubmission` on success or an `ExercismClientError` on failure.
-    public func cancelTestRun(withLink link: String,
-                              completed: @escaping (Result<TestSubmission, ExercismClientError>) -> Void) {
-        networkClient.get(from: URL(string: link)!,
-                          headers: headers(),
-                          completed: completed)
+    /// - Parameter link: The URL link to cancel the test run.
+    /// - Returns: A `TestSubmission` representing the canceled test run.
+    /// - Throws: An `ExercismClientError` if the request or decoding fails.
+    public func cancelTestRun(withLink link: String) async throws -> TestSubmission {
+        guard let url = URL(string: link) else {
+            throw ExercismClientError.builderError(message: "Invalid URL")
+        }
+        return try await networkClient.get(from: url, headers: headers())
     }
     
-    /// Submits a solution for review.
+    /// Submits a solution for review after successfully running and passing all tests.
     ///
-    /// This action is performed after successfully running and passing all tests.
-    ///
-    /// - Parameters:
-    ///   - link: The URL used to submit the solution.
-    ///   - completed: A completion handler returning a `Result` with either a `SubmitSolutionResponse` on success or an `ExercismClientError` on failure.
-    public func submitSolution(withLink link: String,
-        completed: @escaping (Result<SubmitSolutionResponse, ExercismClientError>) -> Void) {
-            guard let url = URL(string: link) else {
-                completed(.failure(.builderError(message: "Invalid URL")))
-                return
-            }
-            
-            networkClient.post(to: url,
-                body: "",
-                headers: headers(),
-                completed: completed
-            )
+    /// - Parameter link: The URL used to submit the solution.
+    /// - Returns: A `SubmitSolutionResponse` indicating the result of the submission.
+    /// - Throws: An `ExercismClientError` if the request or decoding fails.
+    public func submitSolution(withLink link: String) async throws -> SubmitSolutionResponse {
+        guard let url = URL(string: link) else {
+            throw ExercismClientError.builderError(message: "Invalid URL")
         }
+        return try await networkClient.post(to: url, body: "", headers: headers())
+    }
     
     /// Marks a solution as complete, optionally publishing it and specifying an iteration.
-    ///
-    /// This action is performed after submitting the solution and successfully passing all tests.
     ///
     /// - Parameters:
     ///   - solution: The identifier of the solution to be completed.
     ///   - publish: A boolean indicating whether to publish the solution (default is `false`).
     ///   - iteration: An optional iteration number to complete, if applicable.
-    ///   - completed: A completion handler returning a `Result` with either a `CompletedSolution` on success or an `ExercismClientError` on failure.
+    /// - Returns: A `CompletedSolution` indicating the result of the completion action.
+    /// - Throws: An `ExercismClientError` if the request or decoding fails.
     public func completeSolution(for solution: String,
                                  publish: Bool = false,
-                                 iteration: Int? = nil,
-                                 completed: @escaping (Result<CompletedSolution, ExercismClientError>) -> Void) {
+                                 iteration: Int? = nil) async throws -> CompletedSolution {
         let payload = CompleteSolutionPayload(publish: publish, iteration: iteration)
-        networkClient.patch(to: urlBuilder.url(for: .completeSolution,
-                                               urlArgs: solution),
-                            body: payload,
-                            headers: headers(),
-                            completed: completed)
+        return try await networkClient.patch(to: urlBuilder.url(for: .completeSolution,
+                                                                urlArgs: solution),
+                                             body: payload,
+                                             headers: headers())
     }
 }
+

--- a/Sources/ExercismSwift/ExercismClient+Submissions.swift
+++ b/Sources/ExercismSwift/ExercismClient+Submissions.swift
@@ -14,7 +14,7 @@ extension ExercismClient {
     /// - Returns: A `TestSubmission` result from the test run.
     /// - Throws: An `ExercismClientError` if the request or decoding fails.
     public func runTest(for solution: String,
-                        with contents: [SolutionFileData]) async throws -> TestSubmission {
+                        with contents: [SolutionFileData]) async throws(ExercismClientError) -> TestSubmission {
         let files = SolutionTestFiles(files: contents)
         return try await networkClient.post(to: urlBuilder.url(for: .testSubmission,
                                                                urlArgs: solution),
@@ -27,7 +27,7 @@ extension ExercismClient {
     /// - Parameter link: The URL link to fetch the test run status.
     /// - Returns: A `TestRunResponse` representing the current status of the test run.
     /// - Throws: An `ExercismClientError` if the request or decoding fails.
-    public func getTestRun(withLink link: String) async throws -> TestRunResponse {
+    public func getTestRun(withLink link: String) async throws(ExercismClientError) -> TestRunResponse {
         guard let url = URL(string: link) else {
             throw ExercismClientError.builderError(message: "Invalid URL")
         }
@@ -39,7 +39,7 @@ extension ExercismClient {
     /// - Parameter link: The URL link to cancel the test run.
     /// - Returns: A `TestSubmission` representing the canceled test run.
     /// - Throws: An `ExercismClientError` if the request or decoding fails.
-    public func cancelTestRun(withLink link: String) async throws -> TestSubmission {
+    public func cancelTestRun(withLink link: String) async throws(ExercismClientError) -> TestSubmission {
         guard let url = URL(string: link) else {
             throw ExercismClientError.builderError(message: "Invalid URL")
         }
@@ -51,7 +51,7 @@ extension ExercismClient {
     /// - Parameter link: The URL used to submit the solution.
     /// - Returns: A `SubmitSolutionResponse` indicating the result of the submission.
     /// - Throws: An `ExercismClientError` if the request or decoding fails.
-    public func submitSolution(withLink link: String) async throws -> SubmitSolutionResponse {
+    public func submitSolution(withLink link: String) async throws(ExercismClientError) -> SubmitSolutionResponse {
         guard let url = URL(string: link) else {
             throw ExercismClientError.builderError(message: "Invalid URL")
         }
@@ -68,7 +68,7 @@ extension ExercismClient {
     /// - Throws: An `ExercismClientError` if the request or decoding fails.
     public func completeSolution(for solution: String,
                                  publish: Bool = false,
-                                 iteration: Int? = nil) async throws -> CompletedSolution {
+                                 iteration: Int? = nil) async throws(ExercismClientError) -> CompletedSolution {
         let payload = CompleteSolutionPayload(publish: publish, iteration: iteration)
         return try await networkClient.patch(to: urlBuilder.url(for: .completeSolution,
                                                                 urlArgs: solution),

--- a/Sources/ExercismSwift/ExercismClient+Tracks.swift
+++ b/Sources/ExercismSwift/ExercismClient+Tracks.swift
@@ -8,6 +8,6 @@ extension ExercismClient {
     /// - Returns: An array of `Track` objects available to the user.
     /// - Throws: An `ExercismClientError` if the request fails or decoding fails.
     public func tracks() async throws(ExercismClientError) -> ListResponse<Track> {
-        try await networkClient.get(from: urlBuilder.url(for: .tracks), headers: headers())
+        try await networkClient.get(from: urlBuilder.url(for: .tracks), headers: headers)
     }
 }

--- a/Sources/ExercismSwift/ExercismClient+Tracks.swift
+++ b/Sources/ExercismSwift/ExercismClient+Tracks.swift
@@ -7,7 +7,7 @@ extension ExercismClient {
     ///
     /// - Returns: An array of `Track` objects available to the user.
     /// - Throws: An `ExercismClientError` if the request fails or decoding fails.
-    public func tracks() async throws -> ListResponse<Track> {
+    public func tracks() async throws(ExercismClientError) -> ListResponse<Track> {
         try await networkClient.get(from: urlBuilder.url(for: .tracks), headers: headers())
     }
 }

--- a/Sources/ExercismSwift/ExercismClient+Tracks.swift
+++ b/Sources/ExercismSwift/ExercismClient+Tracks.swift
@@ -5,11 +5,9 @@ import Foundation
 extension ExercismClient {
     /// Fetches a list of available tracks.
     ///
-    /// - Parameter completed: A completion handler returning a `Result` with either a `ListResponse<Track>` on success or an `ExercismClientError` on failure.
-    public func tracks(completed: @escaping (Result<ListResponse<Track>,
-                                             ExercismClientError>) -> Void) {
-        networkClient.get(from: urlBuilder.url(for: .tracks),
-                          headers: headers(),
-                          completed: completed)
+    /// - Returns: An array of `Track` objects available to the user.
+    /// - Throws: An `ExercismClientError` if the request fails or decoding fails.
+    public func tracks() async throws -> ListResponse<Track> {
+        try await networkClient.get(from: urlBuilder.url(for: .tracks), headers: headers())
     }
 }

--- a/Sources/ExercismSwift/ExercismClient+ValidateToken.swift
+++ b/Sources/ExercismSwift/ExercismClient+ValidateToken.swift
@@ -5,11 +5,10 @@ import Foundation
 extension ExercismClient {
     /// Validates the user's authentication token.
     ///
-    /// - Parameter completed: A completion handler returning a `Result` with either a `ValidateTokenResponse` on success or an `ExercismClientError` on failure.
-    public func validateToken(completed: @escaping (Result<ValidateTokenResponse,
-                                                    ExercismClientError>) -> Void) {
-        networkClient.get(from: urlBuilder.url(for: .validateToken),
-                          headers: headers(),
-                          completed: completed)
+    /// - Returns: A `ValidateTokenResponse` indicating whether the token is valid.
+    /// - Throws: An `ExercismClientError` if the request fails or decoding fails.
+    public func validateToken() async throws -> ValidateTokenResponse {
+        try await networkClient.get(from: urlBuilder.url(for: .validateToken),
+                                    headers: headers())
     }
 }

--- a/Sources/ExercismSwift/ExercismClient+ValidateToken.swift
+++ b/Sources/ExercismSwift/ExercismClient+ValidateToken.swift
@@ -9,6 +9,6 @@ extension ExercismClient {
     /// - Throws: An `ExercismClientError` if the request fails or decoding fails.
     public func validateToken() async throws(ExercismClientError) -> ValidateTokenResponse {
         try await networkClient.get(from: urlBuilder.url(for: .validateToken),
-                                    headers: headers())
+                                    headers: headers)
     }
 }

--- a/Sources/ExercismSwift/ExercismClient+ValidateToken.swift
+++ b/Sources/ExercismSwift/ExercismClient+ValidateToken.swift
@@ -7,7 +7,7 @@ extension ExercismClient {
     ///
     /// - Returns: A `ValidateTokenResponse` indicating whether the token is valid.
     /// - Throws: An `ExercismClientError` if the request fails or decoding fails.
-    public func validateToken() async throws -> ValidateTokenResponse {
+    public func validateToken() async throws(ExercismClientError) -> ValidateTokenResponse {
         try await networkClient.get(from: urlBuilder.url(for: .validateToken),
                                     headers: headers())
     }

--- a/Sources/ExercismSwift/ExercismClient.swift
+++ b/Sources/ExercismSwift/ExercismClient.swift
@@ -11,7 +11,9 @@ public final class ExercismClient: ExercismClientType {
     
     /// The URL builder used to construct API request URLs.
     let urlBuilder = URLBuilder()
-    
+
+    var headers: Network.HTTPHeaders = [:]
+
     /// Initializes the client with an API token and an optional network client.
     /// - Parameters:
     ///   - apiToken: The API token for authentication.
@@ -26,11 +28,5 @@ public final class ExercismClient: ExercismClientType {
     /// - Parameter networkClient: An optional network client. If `nil`, a `DefaultNetworkClient` is used.
     public init(networkClient: NetworkClient? = nil) {
         self.networkClient = networkClient ?? DefaultNetworkClient(apiToken)
-    }
-    
-    /// Returns the default HTTP headers used for network requests.
-    /// - Returns: A dictionary of HTTP headers.
-    func headers() -> Network.HTTPHeaders {
-        [:]
     }
 }

--- a/Sources/ExercismSwift/ExercismClientError.swift
+++ b/Sources/ExercismSwift/ExercismClientError.swift
@@ -18,7 +18,10 @@ public enum ExercismClientError: Error {
         case .genericError(let underlyingError):
             return "An error occurred: \(underlyingError)"
         case .apiError(let code, let type, let message):
-            return "API Error - Code: \(code.rawValue), Type: \(type), Message: \(message)"
+            return """
+            Error Type: \(type)
+            Message: \(message)
+            """
         case .bodyEncodingError(let underlyingError):
             return "Error encoding request body: \(underlyingError.localizedDescription)"
         case .decodingError(let underlyingError):
@@ -46,7 +49,7 @@ public enum ExercismErrorCode: String {
     case invalidRequestURL = "invalid_request_url"
     case invalidRequest = "invalid_request"
     case validationError = "validation_error"
-    case unauthorized = "unauthorized"
+    case unauthorised = "unauthorised"
     case invalidToken = "invalid_auth_token"
     case genericError
 }

--- a/Sources/ExercismSwift/ExercismClientError.swift
+++ b/Sources/ExercismSwift/ExercismClientError.swift
@@ -7,6 +7,11 @@ public enum ExercismClientError: Error {
     case decodingError(Error)
     case unsupportedResponseError
     case builderError(message: String)
+    case notConnectedToInternet
+    case timedOut
+    case cancelled
+    case badURL
+    case invalidRequestURL(URLError.Code)
     
     public var description: String {
         switch self {
@@ -22,6 +27,16 @@ public enum ExercismClientError: Error {
             return "Received an unsupported response"
         case .builderError(let message):
             return "Builder Error: \(message)"
+        case .notConnectedToInternet:
+            return "No internet connection"
+        case .timedOut:
+            return "The request timed out"
+        case .cancelled:
+            return "The request was cancelled"
+        case .badURL:
+            return "The request URL was invalid"
+        case .invalidRequestURL(let code):
+            return "Invalid request URL (URLError.Code: \(code.rawValue))"
         }
     }
 }

--- a/Sources/ExercismSwift/ExercismClientError.swift
+++ b/Sources/ExercismSwift/ExercismClientError.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public enum ExercismClientError: Error {
-    case genericError(Error)
+    case genericError(String)
     case apiError(code: ExercismErrorCode, type: String, message: String)
     case bodyEncodingError(Error)
     case decodingError(Error)
@@ -16,7 +16,7 @@ public enum ExercismClientError: Error {
     public var description: String {
         switch self {
         case .genericError(let underlyingError):
-            return "An error occurred: \(underlyingError.localizedDescription)"
+            return "An error occurred: \(underlyingError)"
         case .apiError(let code, let type, let message):
             return "API Error - Code: \(code.rawValue), Type: \(type), Message: \(message)"
         case .bodyEncodingError(let underlyingError):

--- a/Sources/ExercismSwift/ExercismClientError.swift
+++ b/Sources/ExercismSwift/ExercismClientError.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public enum ExercismClientError: Error {
     case genericError(String)
-    case apiError(code: ExercismErrorCode, type: String, message: String)
+    case apiError(type: String, message: String)
     case bodyEncodingError(Error)
     case decodingError(Error)
     case unsupportedResponseError
@@ -17,7 +17,7 @@ public enum ExercismClientError: Error {
         switch self {
         case .genericError(let underlyingError):
             return "An error occurred: \(underlyingError)"
-        case .apiError(let code, let type, let message):
+        case .apiError(let type, let message):
             return """
             Error Type: \(type)
             Message: \(message)
@@ -44,7 +44,7 @@ public enum ExercismClientError: Error {
     }
 }
 
-public enum ExercismErrorCode: String {
+enum ExercismErrorCode: String {
     case invalidJson = "invalid_json"
     case invalidRequestURL = "invalid_request_url"
     case invalidRequest = "invalid_request"

--- a/Sources/ExercismSwift/ExercismClientPath.swift
+++ b/Sources/ExercismSwift/ExercismClientPath.swift
@@ -5,7 +5,7 @@
 //  Created by Angie Mugo on 26/09/2022.
 //
 
-public enum ExercismClientPath: String {
+enum ExercismClientPath: String {
     case exercises = "/v2/tracks/%@/exercises"
     case tracks = "/v2/tracks"
     case validateToken = "/v2/validate_token"

--- a/Sources/ExercismSwift/ExercismClientType.swift
+++ b/Sources/ExercismSwift/ExercismClientType.swift
@@ -1,45 +1,34 @@
 import Foundation
 
 public protocol ExercismClientType: AnyObject {
-    func tracks(completed: @escaping (Result<ListResponse<Track>,
-                                      ExercismClientError>) -> Void)
+    func tracks() async throws -> ListResponse<Track>
     
-    func exercises(for track: String,
-                   completed: @escaping (Result<ListResponse<Exercise>,
-                                         ExercismClientError>) -> Void)
+    func exercises(for track: String) async throws -> ListResponse<Exercise>
     
-    func validateToken(completed: @escaping (Result<ValidateTokenResponse,
-                                             ExercismClientError>) -> Void)
+    func validateToken() async throws -> ValidateTokenResponse
     
     func solutions(for track: String?,
                    withStatus status: SolutionStatus?,
-                   mentoringStatus: MentoringStatus?,
-                   completed: @escaping (Result<ListResponse<Solution>,
-                                         ExercismClientError>) -> Void)
+                   mentoringStatus: MentoringStatus?) async throws -> ListResponse<Solution>
     
     func downloadSolution(with id: String,
                           for track: String,
-                          exercise: String,
-                          completed: @escaping (Result<ExerciseDocument,
-                                                ExercismClientError>) -> Void)
+                          exercise: String) async throws -> ExerciseDocument
     
-    func initialSolution(for track: String,
-                         completed: @escaping (Result<InitialFiles,
-                                               ExercismClientError>) -> Void)
-    func getIterations(for solutionId: String,
-                       completed: @escaping (Result<IterationResponse, ExercismClientError>) -> Void)
-    func badges(completed: @escaping (Result<ListResponse<Badge>,
-                                      ExercismClientError>) -> Void)
-    func getTestRun(withLink link: String,
-                    completed: @escaping (Result<TestRunResponse,
-                                          ExercismClientError>) -> Void)
-    func submitSolution(withLink link: String,
-                        completed: @escaping (Result<SubmitSolutionResponse, ExercismClientError>) -> Void)
+    func initialSolution(for track: String) async throws -> InitialFiles
+    
+    func getIterations(for solutionId: String) async throws -> IterationResponse
+    
+    func badges() async throws -> ListResponse<Badge>
+    
+    func getTestRun(withLink link: String) async throws -> TestRunResponse
+    
+    func submitSolution(withLink link: String) async throws -> SubmitSolutionResponse
+    
     func completeSolution(for solution: String,
                           publish: Bool,
-                          iteration: Int?,
-                          completed: @escaping (Result<CompletedSolution, ExercismClientError>) -> Void)
+                          iteration: Int?) async throws -> CompletedSolution
+    
     func runTest(for solution: String,
-                        with contents: [SolutionFileData],
-                        completed: @escaping (Result<TestSubmission, ExercismClientError>) -> Void)
+                 with contents: [SolutionFileData]) async throws -> TestSubmission
 }

--- a/Sources/ExercismSwift/ExercismClientType.swift
+++ b/Sources/ExercismSwift/ExercismClientType.swift
@@ -1,34 +1,34 @@
 import Foundation
 
 public protocol ExercismClientType: AnyObject {
-    func tracks() async throws -> ListResponse<Track>
-    
-    func exercises(for track: String) async throws -> ListResponse<Exercise>
-    
-    func validateToken() async throws -> ValidateTokenResponse
-    
+    func tracks() async throws(ExercismClientError) -> ListResponse<Track>
+
+    func exercises(for track: String) async throws(ExercismClientError) -> ListResponse<Exercise>
+
+    func validateToken() async throws(ExercismClientError) -> ValidateTokenResponse
+
     func solutions(for track: String?,
                    withStatus status: SolutionStatus?,
-                   mentoringStatus: MentoringStatus?) async throws -> ListResponse<Solution>
-    
+                   mentoringStatus: MentoringStatus?) async throws(ExercismClientError) -> ListResponse<Solution>
+
     func downloadSolution(with id: String,
                           for track: String,
-                          exercise: String) async throws -> ExerciseDocument
-    
-    func initialSolution(for track: String) async throws -> InitialFiles
-    
-    func getIterations(for solutionId: String) async throws -> IterationResponse
-    
-    func badges() async throws -> ListResponse<Badge>
-    
-    func getTestRun(withLink link: String) async throws -> TestRunResponse
-    
-    func submitSolution(withLink link: String) async throws -> SubmitSolutionResponse
-    
+                          exercise: String) async throws(ExercismClientError) -> ExerciseDocument
+
+    func initialSolution(for track: String) async throws(ExercismClientError) -> InitialFiles
+
+    func getIterations(for solutionId: String) async throws(ExercismClientError) -> IterationResponse
+
+    func badges() async throws(ExercismClientError) -> ListResponse<Badge>
+
+    func getTestRun(withLink link: String) async throws(ExercismClientError) -> TestRunResponse
+
+    func submitSolution(withLink link: String) async throws(ExercismClientError) -> SubmitSolutionResponse
+
     func completeSolution(for solution: String,
                           publish: Bool,
-                          iteration: Int?) async throws -> CompletedSolution
-    
+                          iteration: Int?) async throws(ExercismClientError) -> CompletedSolution
+
     func runTest(for solution: String,
-                 with contents: [SolutionFileData]) async throws -> TestSubmission
+                 with contents: [SolutionFileData]) async throws(ExercismClientError) -> TestSubmission
 }

--- a/Sources/ExercismSwift/Models/ExerciseDocument.swift
+++ b/Sources/ExercismSwift/Models/ExerciseDocument.swift
@@ -28,7 +28,7 @@ public struct ExerciseDocument: Sendable {
     ///   - exerciseDirectory: The directory containing the exercise files.
     ///   - solution: The solution file associated with the exercise.
     /// - Throws: An error if the exercise configuration cannot be loaded or if URLs cannot be created.
-    public init(with exerciseDirectory: URL, solution: SolutionFile) throws {
+    public init(with exerciseDirectory: URL, solution: SolutionFile) throws(ExercismClientError) {
         self.solution = solution
         self.directory = exerciseDirectory
 
@@ -41,31 +41,30 @@ public struct ExerciseDocument: Sendable {
     }
 
     /// Converts a list of file paths to absolute URLs, relative to a given directory.
-    /// - Parameters:
-    ///   - paths: The list of file paths.
-    ///   - directory: The base directory.
-    /// - Throws: `URLError` if any URL is invalid.
-    /// - Returns: An array of valid URLs.
-    private static func makeURLs(from paths: [String], relativeTo directory: URL) throws -> [URL] {
-        return try paths.map { path in
+    private static func makeURLs(from paths: [String], relativeTo directory: URL) throws(ExercismClientError) -> [URL] {
+        var urls: [URL] = []
+
+        for path in paths {
             guard let url = URL(string: path, relativeTo: directory) else {
-                throw ExercismClientError.genericError(URLError(.badURL))
+                throw ExercismClientError.builderError(message: "Failed to create URL for path: \(path)")
             }
-            return url
+            urls.append(url)
         }
+
+        return urls
     }
 
     /// Decodes the exercise configuration from a JSON file located at the provided URL.
-    ///
     /// When a solution file is fetched, it contains a `.exercism/config.json` directory with the exercise configuration
-    ///
-    /// - Parameter url: The URL pointing to the JSON configuration file.
-    /// - Throws: An error if the data cannot be loaded or decoded.
-    /// - Returns: An `ExerciseConfig` instance parsed from the JSON file.
-    static private func decodeConfig(for url: URL) throws -> ExerciseConfig {
-        let data = try Data(contentsOf: url)
+    static private func decodeConfig(for url: URL) throws(ExercismClientError) -> ExerciseConfig {
+        guard let data = try? Data(contentsOf: url) else {
+            throw ExercismClientError.builderError(message: "Failed to load configuration file at \(url)")
+        }
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
-        return try decoder.decode(ExerciseConfig.self, from: data)
+        guard let config = try? decoder.decode(ExerciseConfig.self, from: data) else {
+            throw ExercismClientError.builderError(message: "Failed to decode configuration file at \(url)")
+        }
+        return config
     }
 }

--- a/Sources/ExercismSwift/Network/NetworkClient.swift
+++ b/Sources/ExercismSwift/Network/NetworkClient.swift
@@ -259,7 +259,6 @@ class DefaultNetworkClient: NetworkClient {
             return destPath
         } catch {
             throw NetworkClientHelpers.extractError(error: error)
-
         }
     }
     
@@ -320,6 +319,8 @@ class DefaultNetworkClient: NetworkClient {
             DebugEnvironment.log.trace(String(data: data, encoding: .utf8) ?? "")
             let result = try self.decoder.decode(T.self, from: data)
             return result
+        } catch let error as ExercismClientError {
+            throw error
         } catch {
             throw NetworkClientHelpers.extractError(error: error)
         }

--- a/Sources/ExercismSwift/Network/NetworkClient.swift
+++ b/Sources/ExercismSwift/Network/NetworkClient.swift
@@ -8,11 +8,6 @@ public enum Network {
     public enum HTTPMethod: String {
         case GET, POST, PUT, PATCH, DELETE
     }
-    
-    public enum Errors: Error {
-        case HTTPError(code: Int)
-        case genericError(Error)
-    }
 }
 
 /// A protocol defining a network client for making HTTP requests.
@@ -322,7 +317,8 @@ class DefaultNetworkClient: NetworkClient {
             guard let httpResponse = response as? HTTPURLResponse, (200...299).contains(httpResponse.statusCode) else {
                 throw NetworkClientHelpers.extractError(data: data, response: response)
             }
-            let result = try JSONDecoder().decode(T.self, from: data)
+            DebugEnvironment.log.trace(String(data: data, encoding: .utf8) ?? "")
+            let result = try self.decoder.decode(T.self, from: data)
             return result
         } catch {
             throw NetworkClientHelpers.extractError(error: error)

--- a/Sources/ExercismSwift/Network/NetworkClient.swift
+++ b/Sources/ExercismSwift/Network/NetworkClient.swift
@@ -19,63 +19,53 @@ public enum Network {
 ///
 /// Conforming types should implement methods for performing common HTTP operations such as GET, POST, PATCH, DELETE, and downloading files.
 public protocol NetworkClient: AnyObject {
-    
+
     /// A dictionary of HTTP headers that will be included in all requests.
     var headers: Network.HTTPHeaders { get }
-    
+
     /// Performs an HTTP GET request.
     /// - Parameters:
     ///   - url: The URL to send the request to.
     ///   - headers: Optional additional headers to include in the request.
-    ///   - completed: A closure returning a `Result` with a decoded response or an error.
-    func get<R: Decodable>(from url: URL,
-                           headers: Network.HTTPHeaders?,
-                           completed: @escaping (Result<R, ExercismClientError>) -> Void )
-    
+    /// - Returns: A decoded response of type `R`.
+    /// - Throws: An `ExercismClientError` if the request fails or decoding fails.
+    func get<R: Decodable>(from url: URL, headers: Network.HTTPHeaders?) async throws(ExercismClientError) -> R
+
     /// Performs an HTTP POST request.
     /// - Parameters:
     ///   - url: The URL to send the request to.
     ///   - body: The request body, encoded as JSON.
     ///   - headers: Optional additional headers to include in the request.
-    ///   - completed: A closure returning a `Result` with a decoded response or an error.
-    func post<T: Encodable, R: Decodable>(to url: URL,
-                                          body: T,
-                                          headers: Network.HTTPHeaders?,
-                                          completed: @escaping (Result<R, ExercismClientError>) -> Void)
-    
+    /// - Returns: A decoded response of type `R`.
+    /// - Throws: An `ExercismClientError` if encoding, network, or decoding fails.
+    func post<T: Encodable, R: Decodable>(to url: URL, body: T, headers: Network.HTTPHeaders?) async throws(ExercismClientError) -> R
+
     /// Performs an HTTP PATCH request.
     /// - Parameters:
     ///   - url: The URL to send the request to.
     ///   - body: The request body, encoded as JSON.
     ///   - headers: Optional additional headers to include in the request.
-    ///   - completed: A closure returning a `Result` with a decoded response or an error.
-    func patch<T: Encodable, R: Decodable>(to url: URL,
-                                           body: T,
-                                           headers: Network.HTTPHeaders?,
-                                           completed: @escaping (Result<R, ExercismClientError>) -> Void)
-    
+    /// - Returns: A decoded response of type `R`.
+    /// - Throws: An `ExercismClientError` if encoding, network, or decoding fails.
+    func patch<T: Encodable, R: Decodable>(to url: URL, body: T, headers: Network.HTTPHeaders?) async throws(ExercismClientError) -> R
+
     /// Performs an HTTP DELETE request with a request body.
     /// - Parameters:
     ///   - url: The URL to send the request to.
     ///   - body: The request body, encoded as JSON.
     ///   - headers: Optional additional headers to include in the request.
-    ///   - completed: A closure returning a `Result` with a decoded response or an error.
-    func delete<T: Encodable, R: Decodable>(from url: URL,
-                                            body: T,
-                                            headers: Network.HTTPHeaders?,
-                                            completed: @escaping (Result<R, ExercismClientError>) -> Void)
-    
-    
+    /// - Returns: A decoded response of type `R`.
+    /// - Throws: An `ExercismClientError` if encoding, network, or decoding fails.
+    func delete<T: Encodable, R: Decodable>(from url: URL, body: T, headers: Network.HTTPHeaders?) async throws(ExercismClientError) -> R
+
     /// Downloads a file from a given URL and saves it to a specified destination.
     /// - Parameters:
     ///   - sourcePath: The URL of the file to download.
     ///   - destPath: The local file URL where the downloaded file should be saved.
     ///   - headers: Optional additional headers to include in the request.
-    ///   - completed: A closure returning a `Result` with the local file URL or an error.
-    func download(from sourcePath: URL,
-                  to destPath: URL,
-                  headers: Network.HTTPHeaders?,
-                  completed: @escaping (Result<URL, ExercismClientError>) -> Void)
+    /// - Returns: The local file URL where the file was saved.
+    /// - Throws: An `ExercismClientError` if the download or file operation fails.
+    func download(from sourcePath: URL, to destPath: URL, headers: Network.HTTPHeaders?) async throws(ExercismClientError) -> URL
 }
 
 /// This is the  default implementation of a network client that handles HTTP requests and responses.
@@ -120,62 +110,78 @@ class DefaultNetworkClient: NetworkClient {
         defaultHeaders
     }
     
-    /// Performs a GET request to the specified URL.
+    /// Performs an HTTP GET request to the specified URL and decodes the response.
+    ///
+    /// This method:
+    /// - Constructs a GET request with optional custom headers.
+    /// - Sends the request asynchronously using `URLSession`.
+    /// - Validates the response and decodes it into the specified type `R`.
+    ///
     /// - Parameters:
-    ///   - url: The target URL for the request.
-    ///   - headers: Optional custom headers for the request.
-    ///   - completed: A completion handler returning a `Result` containing the decoded response or an error.
+    ///   - url: The target URL for the GET request.
+    ///   - headers: Optional headers to include in the request.
+    /// - Returns: A decoded response of type `R`.
+    /// - Throws: An `ExercismClientError` if the request fails or decoding fails.
     func get<R: Decodable>(from url: URL,
-                           headers: Network.HTTPHeaders? = nil,
-                           completed: @escaping (Result<R, ExercismClientError>) -> Void) {
+                           headers: Network.HTTPHeaders? = nil) async throws(ExercismClientError) -> R {
         let request = buildRequest(method: .GET, url: url, headers: headers)
-        executeRequest(request: request, completed: completed)
+        return try await executeRequest(request: request)
     }
     
-    /// Performs a POST request with a request body.
+    /// Performs an HTTP POST request with a JSON-encoded request body and decodes the response.
+    ///
+    /// This method:
+    /// - Constructs a POST request with optional headers and an encoded body.
+    /// - Sends the request asynchronously using `URLSession`.
+    /// - Validates the response and decodes it into the specified type `R`.
+    ///
     /// - Parameters:
-    ///   - url: The target URL for the request.
-    ///   - body: The request body to be sent.
-    ///   - headers: Optional custom headers.
-    ///   - completed: A completion handler returning a `Result` containing the decoded response or an error.
+    ///   - url: The target URL for the POST request.
+    ///   - body: A value conforming to `Encodable` to be sent as the request body.
+    ///   - headers: Optional headers to include in the request.
+    /// - Returns: A decoded response of type `R`.
+    /// - Throws: An `ExercismClientError` if encoding, network, or decoding fails.
     func post<T: Encodable, R: Decodable>(to url: URL,
                                           body: T,
-                                          headers: Network.HTTPHeaders? = nil,
-                                          completed: @escaping (Result<R, ExercismClientError>) -> Void) {
+                                          headers: Network.HTTPHeaders? = nil) async throws(ExercismClientError) -> R {
         var request = buildRequest(method: .POST, url: url, headers: headers)
         let requestBody: Data
         
         do {
             requestBody = try encoder.encode(body)
         } catch {
-            completed(.failure(.bodyEncodingError(error)))
-            return
+            throw NetworkClientHelpers.extractError(error: error)
         }
         DebugEnvironment.log.trace("BODY:\n " + String(data: requestBody, encoding: .utf8)!)
         request.httpBody = requestBody
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         
-        executeRequest(request: request, completed: completed)
+        return try await executeRequest(request: request)
     }
     
-    /// Performs a PATCH request with a request body.
+    /// Performs an HTTP PATCH request with a JSON-encoded request body and decodes the response.
+    ///
+    /// This method:
+    /// - Constructs a PATCH request with optional headers and an encoded body.
+    /// - Sends the request asynchronously using `URLSession`.
+    /// - Validates the response and decodes it into the specified type `R`.
+    ///
     /// - Parameters:
-    ///   - url: The target URL for the request.
-    ///   - body: The request body to be sent.
-    ///   - headers: Optional custom headers.
-    ///   - completed: A completion handler returning a `Result` containing the decoded response or an error.
+    ///   - url: The target URL for the PATCH request.
+    ///   - body: A value conforming to `Encodable` to be sent as the request body.
+    ///   - headers: Optional headers to include in the request.
+    /// - Returns: A decoded response of type `R`.
+    /// - Throws: An `ExercismClientError` if encoding, network, or decoding fails.
     func patch<T: Encodable, R: Decodable>(to url: URL,
                                            body: T,
-                                           headers: Network.HTTPHeaders? = nil,
-                                           completed: @escaping (Result<R, ExercismClientError>) -> Void) {
+                                           headers: Network.HTTPHeaders? = nil) async throws(ExercismClientError) -> R {
         var request = buildRequest(method: .PATCH, url: url, headers: headers)
         let requestBody: Data
-        
+
         do {
             requestBody = try encoder.encode(body)
         } catch {
-            completed(.failure(.bodyEncodingError(error)))
-            return
+            throw NetworkClientHelpers.extractError(error: error)
         }
         
         DebugEnvironment.log.trace("BODY:\n " + String(data: requestBody, encoding: .utf8)!)
@@ -183,85 +189,83 @@ class DefaultNetworkClient: NetworkClient {
         request.httpBody = requestBody
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         
-        executeRequest(request: request, completed: completed)
+        return try await executeRequest(request: request)
     }
-    
-    /// Performs a DELETE request with an optional request body.
+
+    /// Performs an HTTP DELETE request with a JSON-encoded request body and decodes the response.
+    ///
+    /// This method:
+    /// - Constructs a DELETE request with the given URL, headers, and encoded body.
+    /// - Sends the request asynchronously using `URLSession`.
+    /// - Validates the response status code.
+    /// - Attempts to decode the response into the expected type `R`.
+    /// - Throws a mapped `ExercismClientError` on failure.
+    ///
     /// - Parameters:
-    ///   - url: The target URL for the request.
-    ///   - body: An optional request body to be sent.
-    ///   - headers: Optional custom headers.
-    ///   - completed: A completion handler returning a `Result` containing the decoded response or an error.
-    func delete<R: Decodable, T: Encodable>(from url: URL,
-                                            body: T,
-                                            headers: Network.HTTPHeaders? = nil,
-                                            completed: @escaping (Result<R, ExercismClientError>) -> Void) {
+    ///   - url: The endpoint to send the DELETE request to.
+    ///   - body: A value conforming to `Encodable` to be used as the request body.
+    ///   - headers: Optional headers to include in the request.
+    /// - Returns: A decoded response of type `R`.
+    /// - Throws: An `ExercismClientError` if encoding, network, or decoding fails.
+    func delete<R: Decodable, T: Encodable>(
+        from url: URL,
+        body: T,
+        headers: Network.HTTPHeaders? = nil) async throws(ExercismClientError) -> R {
         var request = buildRequest(method: .DELETE, url: url, headers: headers)
         let requestBody: Data
-        
+
         do {
             requestBody = try encoder.encode(body)
         } catch {
-            completed(.failure(.bodyEncodingError(error)))
-            return
+            throw NetworkClientHelpers.extractError(error: error)
         }
-        
-        DebugEnvironment.log.trace("BODY:\n " + String(data: requestBody, encoding: .utf8)!)
-        
+
+        DebugEnvironment.log.trace("BODY:\n " + (String(data: requestBody, encoding: .utf8) ?? ""))
         request.httpBody = requestBody
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        
-        executeRequest(request: request, completed: completed)
+
+        return try await executeRequest(request: request)
     }
-    
-    /// Downloads a file from a specified URL and saves it to the given destination path.
+
+
+    /// Downloads a file from the specified URL and saves it to the given destination path.
     ///
-    /// - If successful, if the file exists locally, it is replaced; otherwise, it is created. The completion handler is updated with the destination path
+    /// This method:
+    /// - Constructs a GET request to download a file.
+    /// - Validates that the response status code is within the 2xx range.
+    /// - Saves the downloaded file to the destination URL, replacing it if it already exists.
+    /// - Returns the destination URL if successful.
+    /// - Throws a mapped `ExercismClientError` if the request or file operation fails.
+    ///
     /// - Parameters:
-    ///   - sourcePath: The URL to download the file from.
-    ///   - destPath: The destination URL where the file should be saved.
-    ///   - headers: Optional custom headers.
-    ///   - completed: A completion handler returning a `Result` containing the file URL or an error.
+    ///   - sourcePath: The URL from which to download the file.
+    ///   - destPath: The local destination URL to save the downloaded file.
+    ///   - headers: Optional headers to include in the request.
+    /// - Returns: The `URL` of the saved file.
+    /// - Throws: An `ExercismClientError` if the download or file handling fails.
     func download(from sourcePath: URL,
                   to destPath: URL,
-                  headers: Network.HTTPHeaders? = [:],
-                  completed: @escaping (Result<URL, ExercismClientError>) -> Void) {
+                  headers: Network.HTTPHeaders? = [:]) async throws(ExercismClientError) -> URL {
         let request = initRequest(url: sourcePath, headers: headers)
-        
-        let task = URLSession.shared.downloadTask(with: request) { tempURL, response, error in
-            if let error = NetworkClientHelpers.extractError(response: response, error: error) {
-                DispatchQueue.main.async {
-                    completed(.failure(error))
-                }
-                return
+
+        do {
+            let (tempURL, response) = try await URLSession.shared.download(for: request)
+            guard let httpResponse = response as? HTTPURLResponse, (200...299).contains(httpResponse.statusCode) else {
+                throw NetworkClientHelpers.extractError(data: nil, response: response)
             }
-            
-            guard let tempURL = tempURL else {
-                DispatchQueue.main.async {
-                    completed(.failure(.unsupportedResponseError))
-                }
-                return
-            }
-            
+
             DebugEnvironment.log.trace("Downloaded file location: \(tempURL.description)")
-            
-            do {
-                if FileManager.default.fileExists(atPath: destPath.relativePath) {
-                    try FileManager.default.replaceItemAt(destPath, withItemAt: tempURL)
-                } else {
-                    try FileManager.default.moveItem(at: tempURL, to: destPath)
-                }
-                DispatchQueue.main.async {
-                    completed(.success(destPath))
-                }
-            } catch {
-                DispatchQueue.main.async {
-                    completed(.failure(.genericError(error)))
-                }
+
+            if FileManager.default.fileExists(atPath: destPath.relativePath) {
+                _ = try FileManager.default.replaceItemAt(destPath, withItemAt: tempURL)
+            } else {
+                _ = try FileManager.default.moveItem(at: tempURL, to: destPath)
             }
+            return destPath
+        } catch {
+            throw NetworkClientHelpers.extractError(error: error)
+
         }
-        
-        task.resume()
     }
     
     /// Builds a URL request with the specified HTTP method and headers.
@@ -297,50 +301,31 @@ class DefaultNetworkClient: NetworkClient {
         return request
     }
     
-    /// Executes a network request, processes the response, and decodes it into the specified type.
+    /// Executes a network request asynchronously, validates the response, and decodes it into the specified type.
     ///
-    /// - The method sends an HTTP request using `URLSession.shared.dataTask(with:)`.
-    /// - It checks for errors using `NetworkClientHelpers.extractError(data:response:error:)` and returns a failure if an error is found.
-    /// - If the request succeeds and data is received, it attempts to decode the data into the specified type `T: Decodable`.
-    /// - If decoding fails, it captures and returns a `.decodingError` or a `.genericError`.
-    /// - The result is returned asynchronously on the main thread via the `completed` closure.
+    /// This method performs the following steps:
+    /// - Sends an HTTP request using `URLSession.shared.data(for:)`.
+    /// - Verifies that the HTTP response has a 2xx status code.
+    /// - If the response indicates an error (non-2xx status), it uses `NetworkClientHelpers.extractError(data:response:)` to extract a meaningful `ExercismClientError`.
+    /// - Attempts to decode the received data into the specified `Decodable` type `T`.
+    /// - If decoding fails, it maps the thrown error using `NetworkClientHelpers.extractError(error:)`.
     ///
     /// - Parameters:
     ///   - request: The `URLRequest` to be executed.
-    ///   - completed: A completion handler returning a `Result<T, ExercismClientError>`,
-    ///     where `T` is the expected response type if decoding succeeds, or an error otherwise.
-    private func executeRequest<T: Decodable>(request: URLRequest,
-                                              completed: @escaping (Result<T, ExercismClientError>) -> Void) {
+    /// - Returns: A decoded object of type `T`.
+    /// - Throws: An `ExercismClientError` if the request fails, the response is invalid, or decoding fails.
+    private func executeRequest<T: Decodable>(request: URLRequest) async throws(ExercismClientError) -> T {
         DebugEnvironment.log.debug("Request: \(request.httpMethod ?? "") \(request.url?.absoluteString ?? "")")
-        
-        let task = URLSession.shared.dataTask(with: request) { data, response, error in
-            var completeResult: Result<T, ExercismClientError>?
-            
-            if let error = NetworkClientHelpers.extractError(data: data, response: response, error: error) {
-                completeResult = .failure(error)
-            } else if let data = data {
-                DebugEnvironment.log.trace(String(data: data, encoding: .utf8) ?? "")
-                do {
-                    let result = try self.decoder.decode(T.self, from: data)
-                    completeResult = .success(result)
-                } catch let decodingError as Swift.DecodingError {
-                    completeResult = .failure(.decodingError(decodingError))
-                } catch {
-                    completeResult = .failure(.genericError(error))
-                }
-            } else {
-                completeResult = .failure(.unsupportedResponseError)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse, (200...299).contains(httpResponse.statusCode) else {
+                throw NetworkClientHelpers.extractError(data: data, response: response)
             }
-            
-            DispatchQueue.main.async {
-                guard let completeResult = completeResult else {
-                    fatalError("Unexpected state: No result available!")
-                }
-                completed(completeResult)
-            }
+            let result = try JSONDecoder().decode(T.self, from: data)
+            return result
+        } catch {
+            throw NetworkClientHelpers.extractError(error: error)
         }
-        
-        task.resume()
     }
-    
 }

--- a/Sources/ExercismSwift/Network/NetworkClientHelpers.swift
+++ b/Sources/ExercismSwift/Network/NetworkClientHelpers.swift
@@ -20,8 +20,7 @@ enum NetworkClientHelpers {
         
         if (400..<503).contains(response.statusCode) {
             if let data = data, let err = try? JSONDecoder().decode(ErrorResponse.self, from: data) {
-                return .apiError(code: ExercismErrorCode(rawValue: err.error.type) ?? .genericError,
-                                 type: err.error.type,
+                return .apiError(type: err.error.type,
                                  message: err.error.message)
             }
         }

--- a/Sources/ExercismSwift/Network/NetworkClientHelpers.swift
+++ b/Sources/ExercismSwift/Network/NetworkClientHelpers.swift
@@ -2,28 +2,7 @@ import Foundation
 
 /// A helper utility for handling network errors in the Exercism API client.
 enum NetworkClientHelpers {
-    
-    /// Determines and extracts an `ExercismClientError` from the given network response.
-    ///
-    /// - If a network-related error is provided, it wraps it as a `genericError`.
-    /// - Otherwise, it delegates error extraction to `extractError(data:response:)`,
-    ///   which inspects the response status code and decodes error messages if available.
-    ///
-    /// - Parameters:
-    ///   - data: The response data from the network request, if available.
-    ///   - response: The URL response received from the server.
-    ///   - error: Any network-related error encountered.
-    /// - Returns: An `ExercismClientError` if an error is detected, otherwise `nil`.
-    static func extractError(data: Data?,
-                             response: URLResponse?,
-                             error: Error?) -> ExercismClientError? {
-        if let error = error {
-            return .genericError(error)
-        }
-        
-        return extractError(data: data, response: response)
-    }
-    
+
     /// Parses the HTTP response and extracts an `ExercismClientError` if an error is detected.
     /// - If the response status code is between 400 and 502, it attempts to decode the error response and extract an error message.
     /// - If decoding fails, it returns a generic HTTP error with the response status code.
@@ -33,8 +12,8 @@ enum NetworkClientHelpers {
     ///   - data: The response data from the network request, if available.
     ///   - response: The URL response received from the server.
     /// - Returns: An `ExercismClientError` if an error is detected, otherwise `nil`.
-    private static func extractError(data: Data?,
-                                     response: URLResponse?) -> ExercismClientError? {
+    static func extractError(data: Data?,
+                                     response: URLResponse?) -> ExercismClientError {
         guard let response = response as? HTTPURLResponse else {
             return .unsupportedResponseError
         }
@@ -53,32 +32,48 @@ enum NetworkClientHelpers {
             }
         }
         
-        return nil
+        return .genericError(Network.Errors.HTTPError(code: response.statusCode))
     }
     
-    /// Analyzes the HTTP response and error to determine if an `ExercismClientError` should be returned.
-    /// - If a network-related error is provided, it wraps it as a `genericError`.
-    /// - If the response is missing or invalid, it returns an `unsupportedResponseError`.
-    /// - If the response status code is between 400 and 502, it returns a `genericError` with the corresponding HTTP status code.
+    /// Maps a generic `Error` to a specific `ExercismClientError` with detailed handling for known error types.
     ///
-    /// - Parameters:
-    ///   - response: The URL response received from the server.
-    ///   - error: Any network-related error encountered.
-    /// - Returns: An `ExercismClientError` if an error is detected, otherwise `nil`.
-    static func extractError(response: URLResponse?,
-                             error: Error?) -> ExercismClientError? {
-        if let error = error {
+    /// This function inspects the type of the error and maps it as follows:
+    /// - If the error is a `DecodingError`, returns `.decodingError`.
+    /// - If the error is an `EncodingError`, returns `.bodyEncodingError`.
+    /// - If the error is a `URLError`, inspects the code and returns:
+    ///     - `.notConnectedToInternet` for `.notConnectedToInternet`
+    ///     - `.timedOut` for `.timedOut`
+    ///     - `.cancelled` for `.cancelled`
+    ///     - `.badURL` for `.badURL`
+    ///     - `.invalidRequestURL(code)` for all other `URLError` codes
+    /// - All other errors are returned as `.genericError`.
+    ///
+    /// - Parameter error: The error encountered during the network operation.
+    /// - Returns: A corresponding `ExercismClientError`.
+    static func extractError(error: Error) -> ExercismClientError {
+        switch error {
+        case let decodingError as DecodingError:
+            return .decodingError(decodingError)
+
+        case let encodingError as EncodingError:
+            return .bodyEncodingError(encodingError)
+
+        case let urlError as URLError:
+            switch urlError.code {
+            case .notConnectedToInternet:
+                return .notConnectedToInternet
+            case .timedOut:
+                return .timedOut
+            case .cancelled:
+                return .cancelled
+            case .badURL:
+                return .badURL
+            default:
+                return .invalidRequestURL(urlError.code)
+            }
+
+        default:
             return .genericError(error)
         }
-        
-        guard let response = response as? HTTPURLResponse else {
-            return .unsupportedResponseError
-        }
-        
-        if (400..<503).contains(response.statusCode) {
-            return .genericError(Network.Errors.HTTPError(code: response.statusCode))
-        }
-        
-        return nil
     }
 }

--- a/Sources/ExercismSwift/Network/NetworkClientHelpers.swift
+++ b/Sources/ExercismSwift/Network/NetworkClientHelpers.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// A helper utility for handling network errors in the Exercism API client.
 enum NetworkClientHelpers {
-
+    
     /// Parses the HTTP response and extracts an `ExercismClientError` if an error is detected.
     /// - If the response status code is between 400 and 502, it attempts to decode the error response and extract an error message.
     /// - If decoding fails, it returns a generic HTTP error with the response status code.
@@ -13,20 +13,19 @@ enum NetworkClientHelpers {
     ///   - response: The URL response received from the server.
     /// - Returns: An `ExercismClientError` if an error is detected, otherwise `nil`.
     static func extractError(data: Data?,
-                                     response: URLResponse?) -> ExercismClientError {
+                             response: URLResponse?) -> ExercismClientError {
         guard let response = response as? HTTPURLResponse else {
             return .unsupportedResponseError
         }
         
         if (400..<503).contains(response.statusCode) {
-            if let data = data , let err = try? JSONDecoder().decode(ErrorResponse.self, from: data) {
-                    return .apiError(code: ExercismErrorCode(rawValue: err.error.type) ?? .genericError,
-                                     type: err.error.type,
-                                     message: err.error.message)
+            if let data = data, let err = try? JSONDecoder().decode(ErrorResponse.self, from: data) {
+                return .apiError(code: ExercismErrorCode(rawValue: err.error.type) ?? .genericError,
+                                 type: err.error.type,
+                                 message: err.error.message)
             }
         }
-        
-        return .genericError("Unknown error occurred")
+        return .unsupportedResponseError
     }
     
     /// Maps a generic `Error` to a specific `ExercismClientError` with detailed handling for known error types.
@@ -48,10 +47,10 @@ enum NetworkClientHelpers {
         switch error {
         case let decodingError as DecodingError:
             return .decodingError(decodingError)
-
+            
         case let encodingError as EncodingError:
             return .bodyEncodingError(encodingError)
-
+            
         case let urlError as URLError:
             switch urlError.code {
             case .notConnectedToInternet:
@@ -65,9 +64,9 @@ enum NetworkClientHelpers {
             default:
                 return .invalidRequestURL(urlError.code)
             }
-
+            
         default:
-            return .genericError("Unknown error occurred: \(error.localizedDescription)")
+            return .genericError("\(error.localizedDescription)")
         }
     }
 }

--- a/Sources/ExercismSwift/Network/NetworkClientHelpers.swift
+++ b/Sources/ExercismSwift/Network/NetworkClientHelpers.swift
@@ -19,20 +19,14 @@ enum NetworkClientHelpers {
         }
         
         if (400..<503).contains(response.statusCode) {
-            if let data = data {
-                if let err = try? JSONDecoder().decode(ErrorResponse.self, from: data) {
+            if let data = data , let err = try? JSONDecoder().decode(ErrorResponse.self, from: data) {
                     return .apiError(code: ExercismErrorCode(rawValue: err.error.type) ?? .genericError,
                                      type: err.error.type,
                                      message: err.error.message)
-                } else {
-                    return .genericError(Network.Errors.HTTPError(code: response.statusCode))
-                }
-            } else {
-                return .genericError(Network.Errors.HTTPError(code: response.statusCode))
             }
         }
         
-        return .genericError(Network.Errors.HTTPError(code: response.statusCode))
+        return .genericError("Unknown error occurred")
     }
     
     /// Maps a generic `Error` to a specific `ExercismClientError` with detailed handling for known error types.
@@ -73,7 +67,7 @@ enum NetworkClientHelpers {
             }
 
         default:
-            return .genericError(error)
+            return .genericError("Unknown error occurred: \(error.localizedDescription)")
         }
     }
 }

--- a/Sources/ExercismSwift/Responses/ListMeta.swift
+++ b/Sources/ExercismSwift/Responses/ListMeta.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-public struct ListMeta: Decodable {
+struct ListMeta: Decodable {
     public let currentPage: Int
     public let totalCount: Int
     public let totalPages: Int


### PR DESCRIPTION
- [Swift Concurrency](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/concurrency/) has been looking particularly great lately, and it's now time to migrate there.  
- Added typed throws to make error handling safer 
- Slowly adopting [Strict Concurrency](https://developer.apple.com/documentation/swift/adoptingswift6)
- With offline caching being the next big task here, it is the right time to build a simple client 